### PR TITLE
Automatically render RFC table in README when issues change

### DIFF
--- a/.github/workflows/render-table.yml
+++ b/.github/workflows/render-table.yml
@@ -29,3 +29,7 @@ jobs:
             git config --local user.name "GitHub Action"
             git commit -am "chore: update RFC table in README"
           fi
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/render-table.yml
+++ b/.github/workflows/render-table.yml
@@ -15,7 +15,7 @@ jobs:
           cd tools/rfc-render
           npm install
       - name: render table
-        run: node tools/rfc-render/inject-table.js > README.md
+        run: node tools/rfc-render/inject-table.js README.md > README.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: commit changes

--- a/.github/workflows/render-table.yml
+++ b/.github/workflows/render-table.yml
@@ -16,7 +16,6 @@ jobs:
           npm install
       - name: render table
         run: |
-          cat README.md
           node tools/rfc-render/inject-table.js README.md > README.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/render-table.yml
+++ b/.github/workflows/render-table.yml
@@ -21,6 +21,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: commit changes
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git commit -am "chore: update RFC table in README"
+          if git diff-index --quiet HEAD --; then
+            echo "no changes"
+          else
+            echo "committing changes"
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git commit -am "chore: update RFC table in README"
+          fi

--- a/.github/workflows/render-table.yml
+++ b/.github/workflows/render-table.yml
@@ -1,6 +1,7 @@
 name: Render RFC Table
 on: 
-  - pull_request
+  issues:
+    types: [opened,edited,deleted,transferred,assigned,unassigned,labeled,unlabeled]
 
 jobs:
   render:

--- a/.github/workflows/render-table.yml
+++ b/.github/workflows/render-table.yml
@@ -1,5 +1,6 @@
 name: Render RFC Table
-on: [ issues ]
+on: 
+  - pull_request
 
 jobs:
   render:

--- a/.github/workflows/render-table.yml
+++ b/.github/workflows/render-table.yml
@@ -16,7 +16,7 @@ jobs:
           npm install
       - name: render table
         run: |
-          node tools/rfc-render/inject-table.js README.md > README.md
+          node tools/rfc-render/inject-table.js README.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: commit changes

--- a/.github/workflows/render-table.yml
+++ b/.github/workflows/render-table.yml
@@ -15,7 +15,9 @@ jobs:
           cd tools/rfc-render
           npm install
       - name: render table
-        run: node tools/rfc-render/inject-table.js README.md > README.md
+        run: |
+          cat README.md
+          node tools/rfc-render/inject-table.js README.md > README.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: commit changes

--- a/tools/rfc-render/inject-table.js
+++ b/tools/rfc-render/inject-table.js
@@ -3,7 +3,11 @@ const path = require('path');
 const { render } = require('./render-rfc-table');
 
 async function main() {
-  const readmeFile = path.join(__dirname, '..', '..', 'README.md');
+  const readmeFile = process.argv[2];
+  if (!readmeFile) {
+    throw new Error(`usage: ${process.argv[1]} README.md > README.md`);
+  }
+  
   const lines = (await fs.readFile(readmeFile, 'utf-8')).split('\n');
 
   const begin = lines.indexOf('<!--BEGIN_TABLE-->');

--- a/tools/rfc-render/inject-table.js
+++ b/tools/rfc-render/inject-table.js
@@ -9,8 +9,11 @@ async function main() {
   }
 
   console.error(readmeFile);
+  const text = (await fs.readFile(readmeFile, 'utf-8'));
 
-  const lines = (await fs.readFile(readmeFile, 'utf-8')).split('\n');
+  console.error(text);
+
+  const lines = text.split('\n');
 
   console.error(lines);
 

--- a/tools/rfc-render/inject-table.js
+++ b/tools/rfc-render/inject-table.js
@@ -3,6 +3,8 @@ const path = require('path');
 const { render } = require('./render-rfc-table');
 
 async function main() {
+  console.error(await fs.readdir('.'));
+
   const readmeFile = path.resolve(process.argv[2]);
   if (!readmeFile) {
     throw new Error(`usage: ${process.argv[1]} README.md > README.md`);

--- a/tools/rfc-render/inject-table.js
+++ b/tools/rfc-render/inject-table.js
@@ -7,8 +7,10 @@ async function main() {
   if (!readmeFile) {
     throw new Error(`usage: ${process.argv[1]} README.md > README.md`);
   }
-  
+
   const lines = (await fs.readFile(readmeFile, 'utf-8')).split('\n');
+
+  console.error(lines);
 
   const begin = lines.indexOf('<!--BEGIN_TABLE-->');
   const end = lines.indexOf('<!--END_TABLE-->');

--- a/tools/rfc-render/inject-table.js
+++ b/tools/rfc-render/inject-table.js
@@ -7,10 +7,10 @@ async function main() {
 
   const readmeFile = path.resolve(process.argv[2]);
   if (!readmeFile) {
-    throw new Error(`usage: ${process.argv[1]} README.md > README.md`);
+    throw new Error(`usage: ${process.argv[1]} README.md`);
   }
 
-  console.error(readmeFile);
+  console.error(`reading ${readmeFile}`);
   const text = (await fs.readFile(readmeFile, 'utf-8'));
 
   console.error(text);
@@ -27,7 +27,9 @@ async function main() {
   }
 
   const final = [ ...lines.slice(0, begin + 1), ...(await render()), ...lines.slice(end) ];
-  console.log(final.join('\n'));
+
+  console.error(`writing ${readmeFile}`);
+  await fs.writeFile(readmeFile, final.join('\n'));
 }
 
 main().catch(e => {

--- a/tools/rfc-render/inject-table.js
+++ b/tools/rfc-render/inject-table.js
@@ -3,10 +3,12 @@ const path = require('path');
 const { render } = require('./render-rfc-table');
 
 async function main() {
-  const readmeFile = process.argv[2];
+  const readmeFile = path.resolve(process.argv[2]);
   if (!readmeFile) {
     throw new Error(`usage: ${process.argv[1]} README.md > README.md`);
   }
+
+  console.error(readmeFile);
 
   const lines = (await fs.readFile(readmeFile, 'utf-8')).split('\n');
 

--- a/tools/rfc-render/render-rfc-table.js
+++ b/tools/rfc-render/render-rfc-table.js
@@ -14,7 +14,7 @@ exports.render = render;
 
 async function render() {
   const lines = [];
-  const files = await fs.readdir(path.join('..', '..', 'text'));
+  const files = await fs.readdir(path.join(__dirname, '..', '..', 'text'));
 
   const octo = new Octokit({
     auth: process.env.GITHUB_TOKEN


### PR DESCRIPTION
Implements a GitHub workflow which automatically renders a table of RFCs in README.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_
