### PR TITLE
chore: reorder RFC table

### DIFF
--- a/tools/rfc-render/render-rfc-table.js
+++ b/tools/rfc-render/render-rfc-table.js
@@ -3,11 +3,11 @@ const fs = require('fs').promises;
 const path = require('path');
 
 const labels = {
-  'status/ready': { },
-  'status/proposed': { },
-  'status/pending': { },
   'status/final-comment-period': { }, 
+  'status/pending': { },
+  'status/ready': { },
   'status/resolved': { },
+  'status/proposed': { },
 };
 
 exports.render = render;


### PR DESCRIPTION
New order:
- Final comment period
- Pending
- Ready
- Resolved
- Proposed

The rationale is that "final comment period" and "pending" are more actionable for people coming in as they have concrete chance to influence these RFCs.

