### PR TITLE
feat: run markdownlint for PRs

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -16,6 +16,6 @@ jobs:
           cd ../
       - name: run linter
         run: |
-          ./markdownlint-cli/node_modules/.bin/markdownlint -i text/0049-continuous-delivery.md text/**/*.md
+          ./markdownlint-cli/node_modules/.bin/markdownlint -i text/0049-continuous-delivery.md -i text/0092-asset-publishing.md text/**/*.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -14,6 +14,7 @@ jobs:
           npm install --prefix tools/linters
       - name: run linter
         run: |
-          ./tools/linters/node_modules/.bin/markdownlint -c ./tools/linters/markdownlint.json ./*.md text/**/*.md
+          cd ./tools/linters
+          npx --no-install markdownlint -c markdownlint.json ../../*.md ../../text/**/*.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -16,6 +16,6 @@ jobs:
           cd ../
       - name: run linter
         run: |
-          ./markdownlint-cli/node_modules/.bin/markdownlint -i text/0049-continuous-delivery.md -i text/0092-asset-publishing.md text/**/*.md
+          ./markdownlint-cli/node_modules/.bin/markdownlint -i text/0049-continuous-delivery.md text/**/*.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -11,11 +11,9 @@ jobs:
           node-version: 12.x
       - name: install dependencies
         run: |
-          mkdir markdownlint-cli && cd markdownlint-cli
-          npm install markdownlint-cli
-          cd ../
+          npm install --prefix tools/linters
       - name: run linter
         run: |
-          ./markdownlint-cli/node_modules/.bin/markdownlint -i text/0049-continuous-delivery.md -i text/0092-asset-publishing.md text/**/*.md
+          ./tools/linters/node_modules/.bin/markdownlint -c ./tools/linters/markdownlint.json text/**/*.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,21 @@
+name: PR Lint
+on: pull_request
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: install dependencies
+        run: |
+          mkdir markdownlint-cli && cd markdownlint-cli
+          npm install markdownlint-cli
+          cd ../
+      - name: run linter
+        run: |
+          ./markdownlint-cli/node_modules/.bin/markdownlint -i text/0049-continuous-delivery.md -i text/0092-asset-publishing.md text/**/*.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -14,6 +14,6 @@ jobs:
           npm install --prefix tools/linters
       - name: run linter
         run: |
-          ./tools/linters/node_modules/.bin/markdownlint -c ./tools/linters/markdownlint.json text/**/*.md
+          ./tools/linters/node_modules/.bin/markdownlint -c ./tools/linters/markdownlint.json ./*.md text/**/*.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+  "blank_line": false,
+  "fenced-code-language": false,
+  "line_length": {
+    "line_length": 150
+  },
+  "ol-prefix": false,
+  "single-h1": false,
+  "ul-style": false
+}

--- a/0000-template.md
+++ b/0000-template.md
@@ -19,7 +19,7 @@ related issue: (tracking issue number)
 
 > If the proposal involves a new or changed API, include a basic code example.
 > Omit this section if it's not applicable.
-> 
+>
 > Please focus on explaining the motivation so that if this RFC is not accepted,
 > the motivation could be used to develop alternative solutions. In other words,
 > enumerate the constraints you are trying to solve without coupling them too
@@ -37,23 +37,23 @@ related issue: (tracking issue number)
 > implementation to implement. This should get into specifics and corner-cases,
 > and include examples of how the feature is used. Any new terminology should be
 > defined here.
-> 
+>
 > Include any diagrams and/or visualizations that help to demonstrate the design.
 > Here are some tools that we often use:
-> 
+>
 > - [Graphviz](http://graphviz.it/#/gallery/structs.gv)
 > - [PlantText](https://www.planttext.com)
 
 # Drawbacks
 
 > Why should we _not_ do this? Please consider:
-> 
+>
 > - implementation cost, both in term of code size and complexity
 > - whether the proposed feature can be implemented in user space
 > - the impact on teaching people how to use CDK
 > - integration of this feature with other existing and planned features
 > - cost of migrating existing CDK applications (is it a breaking change?)
-> 
+>
 > There are tradeoffs to choosing any path. Attempt to identify them here.
 
 # Rationale and Alternatives
@@ -84,9 +84,9 @@ related issue: (tracking issue number)
 > and how it would affect CDK as whole. Try to use this section as a tool to more
 > fully consider all possible interactions with the project and ecosystem in your
 > proposal. Also consider how this fits into the roadmap for the project.
-> 
+>
 > This is a good place to "dump ideas", if they are out of scope for the RFC you
 > are writing but are otherwise related.
-> 
+>
 > If you have tried and cannot think of any future possibilities, you may simply
 > state that you cannot think of anything.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See [The RFC Life Cycle](#the-rfc-life-cycle) to learn more about the states of
 existing proposals.
 
 <!--BEGIN_TABLE-->
-#|Title|PR|Created By|Champion|Status
+\#|Title|PR|Created By|Champion|Status
 -|-----|--|----------|--------|------
 [95](https://github.com/aws/aws-cdk-rfcs/issues/95)|Cognito Construct Library|[#91](https://github.com/aws/aws-cdk-rfcs/pull/91)|[@nija-at](https://github.com/nija-at)|[@nija-at](https://github.com/nija-at)|pending
 [60](https://github.com/aws/aws-cdk-rfcs/issues/60)|Bazel Build System|[#61](https://github.com/aws/aws-cdk-rfcs/pull/61)|[@CaerusKaru](https://github.com/CaerusKaru)|[@eladb](https://github.com/eladb)|pending
@@ -72,7 +72,7 @@ existing proposals.
 [1](https://github.com/aws/aws-cdk-rfcs/issues/1)|CDK Watch||[@eladb](https://github.com/eladb)||proposed
 <!--END_TABLE-->
 
-## What does all this mean?!
+## What does all this mean?
 
 This document is a lot of information about process thats meant to help guide.
 It is not a set of rules that need to be strictly applied. It is designed to
@@ -177,9 +177,9 @@ CDK/JSII.
   for the proposed feature if one doesn't already exist. Use the tracking issue
   template as a guide. If a tracking issue already exists, make sure to update
   it and assign it to let others know you're working on a proposal.
-- Fork the RFC repo https://github.com/awslabs/aws-cdk-rfcs
+- Fork the [RFC repo](https://github.com/awslabs/aws-cdk-rfcs).
 - Copy `0000-template.md` to `text/<rfc#>-<my-feature>.md` where <rfc#> is the
-  tracking issue number and <my-feature> is the rfc title.
+  tracking issue number and `<my-feature>` is the rfc title.
 - Fill in the RFC. Put care into the details: **We welcome all honest efforts to
   contribute.**.
 - Submit a pull request with the title `RFC: <rfc#> <title>` where <rfc#> is the
@@ -212,7 +212,7 @@ through the process. They can decide when a final comment period is triggered.
 ![rfc-states](https://g.gravizo.com/svg?digraph%20states%20{node%20[shape=ellipse];proposed%20[label%20=%20%22Proposed%22];pending%20[label%20=%20%22Pending%22];fcp%20[label%20=%20%22Final%20Comment%20Period%22];ready%20[label%20=%20%22Ready%22];resolved%20[label%20=%20%22Resolved%22];proposed%20-%3E%20pending%20[label%20=%20%22%20rfc%20pr%20created%22];pending%20-%3E%20pending%20[label%20=%20%22%20revisions%22];pending%20-%3E%20fcp%20[label%20=%20%22core%20team%20approval%20%20%20%20%22];fcp%20-%3E%20pending%20[label%20=%20%22%20revision%20requested%22];fcp%20-%3E%20ready%20[label%20=%20%22%20merged%22];ready%20-%3E%20resolved%20[label%20=%20%22%20implementation%20complete%22];})
 
 <!-- for later reference from renderer -->
-<details> 
+<details>
 <summary></summary>
 custom_mark10
   digraph states {

--- a/text/0049-continuous-delivery.md
+++ b/text/0049-continuous-delivery.md
@@ -4,11 +4,14 @@ This is a specification for the continuous delivery support feature for CDK apps
 
 **_Goal_: Full CI/CD for CDK apps at any complexity.**
 
-The desired developer experience is that teams will be able to "git push" a change into their CDK app repo and have this change automatically picked up, built, tested and deployed according to a deployment flow they define.
+The desired developer experience is that teams will be able to "git push" a change into their CDK app repo and have this change automatically picked
+up, built, tested and deployed according to a deployment flow they define.
 
-Any changes in resources, assets *or stacks* in their apps will automatically be added. To that end, the deployment pipeline itself will also be continuously delivered and updated throughout the same workflow. No manual deployments to production (incl. the pipeline) will be required.
+Any changes in resources, assets *or stacks* in their apps will automatically be added. To that end, the deployment pipeline itself will also be
+continuously delivered and updated throughout the same workflow. No manual deployments to production (incl. the pipeline) will be required.
 
-The only caveat is that **new environments** (account/region) will need to be bootstrapped in advance in order to establish trust with the central pipeline environment and set-up resources needed for deployment such as the assets S3 bucket.
+The only caveat is that **new environments** (account/region) will need to be bootstrapped in advance in order to establish trust with the central
+pipeline environment and set-up resources needed for deployment such as the assets S3 bucket.
 
 - [Requirements](#requirements)
 - [Approach](#approach)
@@ -32,32 +35,47 @@ The only caveat is that **new environments** (account/region) will need to be bo
 
 ## Requirements
 
-This list describes only the minimal set of requirements from this feature. After we release these building blocks, we will look into vending higher-level "one liner" APIs that will make it very easy to get started.
+This list describes only the minimal set of requirements from this feature. After we release these building blocks, we will look into vending
+higher-level "one liner" APIs that will make it very easy to get started.
 
-1. **Deployment system**: the design should focus on building blocks that can be easily integrated into various deployment systems. This spec describes the integration with the CDK CLI and AWS CodePipelines, but it should be applicable to any deployment system.
+1. **Deployment system**: the design should focus on building blocks that can be easily integrated into various deployment systems. This spec
+   describes the integration with the CDK CLI and AWS CodePipelines, but it should be applicable to any deployment system.
 1. **Assets**: Support apps that include all supported assets (S3 files, ECR images)
 1. **Multi-environment**: Support apps that have stacks that target multiple environments (accounts/regions)
 1. **Orchestration**: Allow developers to express complex deployment orchestration based on the capabilities of CodePipeline
-1. **User-defined build+synth runtime**: the runtime environment in which the code is built and the CDK app is synthesized should be fully customizable by the user
-1. **Restricted deployment runtime**: for security reasons, the runtime environment in which deployment is executed will not allow running user code or user-defined image
-1. **Bootstrapping**: it should be possible to leverage existing AWS account stamping tools like AWS CloudFormation StackSets and AWS Control Tower in order to manage bootstrapping at scale.
-1. **Custom replication**: In order to support isolated and air-gapped regions, as well as deployment across partitions, the solution should support customizing how and where assets are published and replicated to.
+1. **User-defined build+synth runtime**: the runtime environment in which the code is built and the CDK app is synthesized should be fully
+   customizable by the user
+1. **Restricted deployment runtime**: for security reasons, the runtime environment in which deployment is executed will not allow running user code
+   or user-defined image
+1. **Bootstrapping**: it should be possible to leverage existing AWS account stamping tools like AWS CloudFormation StackSets and AWS Control Tower in
+   order to manage bootstrapping at scale.
+1. **Custom replication**: In order to support isolated and air-gapped regions, as well as deployment across partitions, the solution should support
+   customizing how and where assets are published and replicated to.
 
 _Considerations:_
 
-* Prefer to use standard CloudFormation pipeline actions to reduce costs, leverage UI and allow restriction of the deployment role to the CloudFormation service principal.
-* Execution of `cdk synth` or `docker build` should not be done in a context with administrative privileges to avoid injection of malicious code into a privileged environment.
+* Prefer to use standard CloudFormation pipeline actions to reduce costs, leverage UI and allow restriction of the deployment role to the
+  CloudFormation service principal.
+* Execution of `cdk synth` or `docker build` should not be done in a context with administrative privileges to avoid injection of malicious code into
+  a privileged environment.
 
 _Non-requirements/assumptions:_
 
 * We assume that **cdk.context.json** is committed into the repo. Any context-fetching will be done manually by users and committed to the repository.
-* There’s a one-to-one mapping between an app and a pipeline. We are not optimizing the experience for multiple apps per pipeline (although technically it should be possible to do it, but it’s not a use case we are focused on).
-* Dependency management, repository and project structure are out of scope: we don’t want to be opinionated about how users should structure their projects. They should be able to use the tools they are familiar with and are available to their teams to structure and modularize their applications.
-* Assets will not be supported in environment-agnostic stacks. [#4131](https://github.com/aws/aws-cdk/pull/4131) proposes that `cdk deploy` will default `env` to the current account/region, which means that the CLI use case will no longer treat stacks as environment-agnostic.
+* There’s a one-to-one mapping between an app and a pipeline. We are not optimizing the experience for multiple apps per pipeline (although
+  technically it should be possible to do it, but it’s not a use case we are focused on).
+* Dependency management, repository and project structure are out of scope: we don’t want to be opinionated about how users should structure their
+  projects. They should be able to use the tools they are familiar with and are available to their teams to structure and modularize their
+  applications.
+* Assets will not be supported in environment-agnostic stacks. [#4131](https://github.com/aws/aws-cdk/pull/4131) proposes that `cdk deploy` will
+  default `env` to the current account/region, which means that the CLI use case will no longer treat stacks as environment-agnostic.
 
 ## Approach
 
-The general approach is that deployment of a CDK app is governed by a central system (e.g. an AWS CodePipeline, a Jenkins system or any other deployment tool). This central deployment system runs within credentials from a central deployment account, which then assumes roles within all other accounts that can then deploy resources to them. This deployment account is referred to as the **tools account** in the [CodePipeline Cross Account Reference Architecture](https://github.com/awslabs/aws-refarch-cross-account-pipeline).
+The general approach is that deployment of a CDK app is governed by a central system (e.g. an AWS CodePipeline, a Jenkins system or any other
+deployment tool). This central deployment system runs within credentials from a central deployment account, which then assumes roles within all other
+accounts that can then deploy resources to them. This deployment account is referred to as the **tools account** in the [CodePipeline Cross Account
+Reference Architecture](https://github.com/awslabs/aws-refarch-cross-account-pipeline).
 
 At a high-level, we will model the deployment process of a CDK app as follows:
 
@@ -65,15 +83,21 @@ At a high-level, we will model the deployment process of a CDK app as follows:
 bootstrap => source => build => synthesis => mutate => publish => deploy
 ```
 
-
-1. **bootstrap**: provision resources required to deploy CDK apps into all environments in advance (such as an S3 bucket, ECR repository and various IAM roles that trust the central deployment account).
+1. **bootstrap**: provision resources required to deploy CDK apps into all environments in advance (such as an S3 bucket, ECR repository and various
+   IAM roles that trust the central deployment account).
 2. **source**: the code is pulled from a source repository (e.g. CodeCommit, GitHub or S3), like any other app.
-3. **build + synthesis**: compiles the CDK app code into an executable program (user-defined) and invokes the compiled executable through `cdk synth` to produce a [cloud assembly](https://github.com/aws/aws-cdk/blob/master/design/cloud-assembly.md) from the app. The cloud assembly includes a CloudFormation template for each stack and asset sources (docker images, s3 files, etc) that must be packaged and published to the asset store in each environment that consumes them.
-4. **mutate**: update stack(s) required by the pipeline. This includes pipeline resources and other auxiliary resources such as regional replication buckets. These stacks are limited to 50KiB and are not allowed to use assets, so they can be deployed without bootstrapping resources.
+3. **build + synthesis**: compiles the CDK app code into an executable program (user-defined) and invokes the compiled executable through `cdk synth`
+   to produce a [cloud assembly](https://github.com/aws/aws-cdk/blob/master/design/cloud-assembly.md) from the app. The cloud assembly includes a
+   CloudFormation template for each stack and asset sources (docker images, s3 files, etc) that must be packaged and published to the asset store in
+   each environment that consumes them.
+4. **mutate**: update stack(s) required by the pipeline. This includes pipeline resources and other auxiliary resources such as regional replication
+   buckets. These stacks are limited to 50KiB and are not allowed to use assets, so they can be deployed without bootstrapping resources.
 5. **publish**: package and publish all assets to asset stores (S3 bucket, ECR repository) so they can be consumed.
-6. **deploy**: stage(s), stacks are deployed to the various environments through some orchestration process (e.g. deploy first to this region, run these canaries, wait for errors, continue to the next stage, etc).
+6. **deploy**: stage(s), stacks are deployed to the various environments through some orchestration process (e.g. deploy first to this region, run
+   these canaries, wait for errors, continue to the next stage, etc).
 
-NOTE: The deployment phase can include any number of stack deployment actions. Each deployment action is responsible deploy a single stack, along with any assets it references.
+NOTE: The deployment phase can include any number of stack deployment actions. Each deployment action is responsible deploy a single stack, along with
+any assets it references.
 
 This following sections describes the design of each component in the toolchain.
 
@@ -81,36 +105,46 @@ This following sections describes the design of each component in the toolchain.
 
 In this stage we compile the CDK app to an executable program through a user-defined build system and synthesize a cloud assembly from it.
 
-We assume a single source repository which masters the CDK app itself. This repo can be structured in any way users wish, and may include multiple modules or just a single one. If users choose to organize their project into modules and master different modules in other repositories, eventually the build artifacts from these builds should be available when the app is synthesized.
+We assume a single source repository which masters the CDK app itself. This repo can be structured in any way users wish, and may include multiple
+modules or just a single one. If users choose to organize their project into modules and master different modules in other repositories, eventually
+the build artifacts from these builds should be available when the app is synthesized.
 
-The only requirement from the build step is the it will have an output artifact that is a cloud-assembly directory which is obtained through `cdk synth` (defaults to `./cdk.out`). Other than that, users can fully control their build environment.
+The only requirement from the build step is the it will have an output artifact that is a cloud-assembly directory which is obtained through `cdk
+synth` (defaults to `./cdk.out`). Other than that, users can fully control their build environment.
 
-The implication is that users will have to manually configure their build step to invoke `cdk synth` when the app is ready (e.g. code has been compiled).
+The implication is that users will have to manually configure their build step to invoke `cdk synth` when the app is ready (e.g. code has been
+compiled).
 
-The CDK synthesizes a CloudFormation template for each stack defined in the CDK app. When stacks are defined, users can specify the target environment (account and region) into which the stack should be deployed:
+The CDK synthesizes a CloudFormation template for each stack defined in the CDK app. When stacks are defined, users can specify the target environment
+(account and region) into which the stack should be deployed:
 
 ```ts
 new Stack(this, 'my-stack', { env: { account: '123456789012', region: 'us-east-1' } });
 ```
 
-**Multiple Environments**
+### Multiple Environments
 
-In order to support deploying stacks from a centralized (pipeline/development) environment to other environments, the bootstrap stack includes a set of named IAM roles which trust the central account for publishing and deployment.
+In order to support deploying stacks from a centralized (pipeline/development) environment to other environments, the bootstrap stack includes a set
+of named IAM roles which trust the central account for publishing and deployment.
 
 In order to encourage separation of concerns and allow customizability, we will add role information to the assembly manifest.
 
 For each stack, we will encode additional two IAM roles:
 
-1. Administrator CloudFormation IAM role which can only be assumed by the CloudFormation service principal (also known as the "action role" in CodePipeline terminology)
-2. Deployment IAM role which can be assumed by any principal from the central account and has permissions to "pass role" on the administrator role (also known as the "CFN role" in CodePipeline terminology).
+1. Administrator CloudFormation IAM role which can only be assumed by the CloudFormation service principal (also known as the "action role" in
+   CodePipeline terminology)
+2. Deployment IAM role which can be assumed by any principal from the central account and has permissions to "pass role" on the administrator role
+   (also known as the "CFN role" in CodePipeline terminology).
 
-> The publisher role which is also provisioned during bootstrapping is encoded in the `assets.json` file *per-asset* to allow for maximum customizability.
+> The publisher role which is also provisioned during bootstrapping is encoded in the `assets.json` file *per-asset* to allow for maximum
+> customizability.
 
 This is the recommended setup for cross-account CloudFormation deployments.
 
-**Assets**
+### Assets
 
-Users can reference "assets" within their CDK app. Assets represent artifacts produced from local files and used by the app at runtime. The CDK currently supports file assets served from Amazon S3 and docker image assets served from Amazon ECR.
+Users can reference "assets" within their CDK app. Assets represent artifacts produced from local files and used by the app at runtime. The CDK
+currently supports file assets served from Amazon S3 and docker image assets served from Amazon ECR.
 
 For example, this is a definition of an AWS Lambda function that uses the code from the `my-handler` directory:
 
@@ -126,32 +160,51 @@ In order for this to work, this is what needs to happen:
 
 1. A zip archive needs to be created from the contents of `my-handler`.
 2. The file needs to be uploaded to an S3 bucket in the stack’s environment.
-3. The `Code` property in the synthesized `AWS::Lambda::Function` resource should point to the S3 URL that will contains this zip file when the stack is deployed.
+3. The `Code` property in the synthesized `AWS::Lambda::Function` resource should point to the S3 URL that will contains this zip file when the stack
+   is deployed.
 
-A similar set of requirements exist for a Docker image built from a local `Dockerfile`, pushed to an ECR repository in the target environment and referenced in the `Image` property of the `AWS::ECS::TaskDefinition` resource.
+A similar set of requirements exist for a Docker image built from a local `Dockerfile`, pushed to an ECR repository in the target environment and
+referenced in the `Image` property of the `AWS::ECS::TaskDefinition` resource.
 
-**Asset Identity**
+### Asset Identity
 
-Assets will be identified throughout the system using a sha256 hash calculated from their source. This is the contents of the asset source directory, Dockerfile or specific file. Using a consistent source hash allows the various tools in the system to avoid duplicated work such as building docker images or transferring large amount of information.
+Assets will be identified throughout the system using a sha256 hash calculated from their source. This is the contents of the asset source directory,
+Dockerfile or specific file. Using a consistent source hash allows the various tools in the system to avoid duplicated work such as building docker
+images or transferring large amount of information.
 
-> **NOTE:** docker builds are technically not deterministic, but this scheme will cause them to be. If the source (Dockerfile or accompanying files) didn’t change, the source hash will stay the same and the asset will not be rebuild/updated. Operationally this is actually a good thing as it will protect against out-of-band updates (we only want commits to cause production updates), but users may rely on this non-deterministic behavior and we need to communicate/enforce somehow.
+> **NOTE:** docker builds are technically not deterministic, but this scheme will cause them to be. If the source (Dockerfile or accompanying files)
+> didn’t change, the source hash will stay the same and the asset will not be rebuild/updated. Operationally this is actually a good thing as it will
+> protect against out-of-band updates (we only want commits to cause production updates), but users may rely on this non-deterministic behavior and we
+> need to communicate/enforce somehow.
 
-**Asset Stores**
+### Asset Stores
 
-The S3 bucket and ECR repository that are used to serve asset artifacts in each target environment are called the "**asset store**". They will be provisioned and populated **before** stacks which use assets can be deployed to this environment. The process of provisioning deployment resources in an AWS environment is called "**bootstrapping**". It provisions the asset store and various IAM roles with permissions to publish assets and to deploy CloudFormation stacks to the environment.
+The S3 bucket and ECR repository that are used to serve asset artifacts in each target environment are called the "**asset store**". They will be
+provisioned and populated **before** stacks which use assets can be deployed to this environment. The process of provisioning deployment resources in
+an AWS environment is called "**bootstrapping**". It provisions the asset store and various IAM roles with permissions to publish assets and to deploy
+CloudFormation stacks to the environment.
 
-In order to minimize the amount of configuration required throughout the deployment pipeline, we decided to double-down on the CDK design tenet that favors early (synthesis-time) binding. In the current implementation, if a CDK stack used asset, CloudFormation parameters are added to templates so that the asset locations were late-bound and resolved by the CLI only after the asset has been published. This approach has two problems:
+In order to minimize the amount of configuration required throughout the deployment pipeline, we decided to double-down on the CDK design tenet that
+favors early (synthesis-time) binding. In the current implementation, if a CDK stack used asset, CloudFormation parameters are added to templates so
+that the asset locations were late-bound and resolved by the CLI only after the asset has been published. This approach has two problems:
 
 1. It resulted in the proliferation of asset parameters (currently 2-3 parameters per asset).
 2. It requires the deployment tool to "wire" the asset parameters to the stack during deployment.
 
-The main issue is #2. Different deployment tools have different ways to configure how parameters are passed to CloudFormation stacks, which makes it difficult to find a general purpose way to convey this information to the deployment stage. Additionally, the publishing and consumption locations must be customizable since different deployment systems may have different ways to publish and replicate assets across environments (for example, a deployment system which needs to be able to deploy to air-gapped regions and requires that all assets are published to a centralized store and then copied to target environments through air gaps).
+The main issue is #2. Different deployment tools have different ways to configure how parameters are passed to CloudFormation stacks, which makes it
+difficult to find a general purpose way to convey this information to the deployment stage. Additionally, the publishing and consumption locations
+must be customizable since different deployment systems may have different ways to publish and replicate assets across environments (for example, a
+deployment system which needs to be able to deploy to air-gapped regions and requires that all assets are published to a centralized store and then
+copied to target environments through air gaps).
 
-The solution is to resolve asset locations **during synthesis** and use naming conventions for bootstrapping resources. This means that asset locations will be concrete values and we can also encode all publishing information to the assembly manifest. It will also allow customizing all publishing behavior from within the CDK app, without the need to supply additional plugin capabilities.
+The solution is to resolve asset locations **during synthesis** and use naming conventions for bootstrapping resources. This means that asset
+locations will be concrete values and we can also encode all publishing information to the assembly manifest. It will also allow customizing all
+publishing behavior from within the CDK app, without the need to supply additional plugin capabilities.
 
-We will synthesize a file called `assets.json`, which will include preparation and publishing instructions for each asset. 
+We will synthesize a file called `assets.json`, which will include preparation and publishing instructions for each asset.
 
-By default, S3 assets will be stored in a single S3 bucket where the object key will be based on the asset's source hash. Docker assets will be stored in a single ECR repository where the image tag will be based on the asset source hash (hash of the contents of the Dockerfile directory).
+By default, S3 assets will be stored in a single S3 bucket where the object key will be based on the asset's source hash. Docker assets will be stored
+in a single ECR repository where the image tag will be based on the asset source hash (hash of the contents of the Dockerfile directory).
 
 For file assets:
 
@@ -172,41 +225,56 @@ For image assets:
   * Image name
   * Publishing Role ARN to assume
 
-**Customizability**
+### Customizability
 
-Asset consumption and publishing locations should be fully customizable. To that end, the `core.Stack` base class will expose an API that will be used by the asset framework to resolve consumption locations and synthesize `assets.json`. This will allow users to provide their own implementation based on their specific needs.
+Asset consumption and publishing locations should be fully customizable. To that end, the `core.Stack` base class will expose an API that will be used
+by the asset framework to resolve consumption locations and synthesize `assets.json`. This will allow users to provide their own implementation based
+on their specific needs.
 
-**Asset Source Staging**
+### Asset Source Staging
 
-During synthesis, the CDK app will _copy the sources_ of all assets from their original location on disk into the cloud assembly output directory. This allows the cloud assembly to be self-contained and is important for the CI/CD use cases (both internal and external) where the cloud assembly is the only artifact needed after build is complete.
+During synthesis, the CDK app will _copy the sources_ of all assets from their original location on disk into the cloud assembly output directory.
+This allows the cloud assembly to be self-contained and is important for the CI/CD use cases (both internal and external) where the cloud assembly is
+the only artifact needed after build is complete.
 
-**Asset Providers**
+### Asset Providers
 
 Users should be able to vend custom asset providers to allow customizing how assets are being referenced or packaged.
 
-For example, a company might have an internal system that manages software artifacts. They can internally vend custom implementations for the `lambda.Code` and `ecs.ContainerImage` classes which will allow users to reference these artifacts and synthesize placeholders into the cloud assembly, which will later be resolved during the publishing stage and identified through a user-defined unique identifier.
+For example, a company might have an internal system that manages software artifacts. They can internally vend custom implementations for the
+`lambda.Code` and `ecs.ContainerImage` classes which will allow users to reference these artifacts and synthesize placeholders into the cloud
+assembly, which will later be resolved during the publishing stage and identified through a user-defined unique identifier.
 
-**Environment-agnostic Stacks**
+### Environment-agnostic Stacks
 
 When a stack is defined, users can specify `env` (account and/or region).
 
-If `account` and/or `region` use the pseudo references `Aws.ACCOUNT_ID` and `Aws.REGION`, respectively, the stack is called "environment-agnostic". Certain features in the CDK, like VPC lookups for example, are not supported for environment-agnostic stacks since the specific account/region is required during synthesis.
+If `account` and/or `region` use the pseudo references `Aws.ACCOUNT_ID` and `Aws.REGION`, respectively, the stack is called "environment-agnostic".
+Certain features in the CDK, like VPC lookups for example, are not supported for environment-agnostic stacks since the specific account/region is
+required during synthesis.
 
-The proposal described in [PR#4131](https://github.com/aws/aws-cdk/pull/4131) suggests that environment-agnostics stacks cannot be deployed using the CDK. However, it also proposes that the default behavior for `env` will be to use ("inherit") the CLI configured environment when a stack is deployed through `cdk deploy`.
+The proposal described in [PR#4131](https://github.com/aws/aws-cdk/pull/4131) suggests that environment-agnostics stacks cannot be deployed using the
+CDK. However, it also proposes that the default behavior for `env` will be to use ("inherit") the CLI configured environment when a stack is deployed
+through `cdk deploy`.
 
 This means that the only way to produce environment-agnostic templates will be to explicitly indicate it when a stack is defined.
 
-Then `cdk-assets` will simply substitute `${AWS::ACCOUNT}` and `${AWS::REGION}` with the account and region derived from the credentials configured for the CLI.
+Then `cdk-assets` will simply substitute `${AWS::ACCOUNT}` and `${AWS::REGION}` with the account and region derived from the credentials configured
+for the CLI.
 
-> NOTE: even when an IAM role from another account is assumed for publishing, `${AWS::ACCOUNT}` and `${AWS::REGION}` always resolve to the CLI configuration and not to the other account.
+> NOTE: even when an IAM role from another account is assumed for publishing, `${AWS::ACCOUNT}` and `${AWS::REGION}` always resolve to the CLI
+> configuration and not to the other account.
 
 ## Bootstrapping
 
-The CDK already has a dedicated tool for bootstrapping environments called **`cdk bootstrap`**. An environment is bootstrapped once, and from that point, it is possible to deploy CDK apps into this environment.
+The CDK already has a dedicated tool for bootstrapping environments called **`cdk bootstrap`**. An environment is bootstrapped once, and from that
+point, it is possible to deploy CDK apps into this environment.
 
-Environment bootstrapping doesn't have to be performed by the development team, and does not require deep knowledge of the application structure, besides the set of accounts and regions into which the app needs to be deployed.
+Environment bootstrapping doesn't have to be performed by the development team, and does not require deep knowledge of the application structure,
+besides the set of accounts and regions into which the app needs to be deployed.
 
-The current implementation only provisions an S3 bucket, but in order to be able to continuously deploy CDK stacks that use asses, we will need the following resources __in each AWS environment (account + region)__:
+The current implementation only provisions an S3 bucket, but in order to be able to continuously deploy CDK stacks that use asses, we will need the
+following resources __in each AWS environment (account + region)__:
 
 For publishing:
 
@@ -216,8 +284,10 @@ For publishing:
 
 For deployment:
 
-* **CloudFormation Role**: IAM role which allows the CloudFormation service principal to deploy stacks into the environment (this role usually has administrative privileges).
-* **Deployment Role**: IAM role which allows anyone from the deployment account to create, update and describe CloudFormation change sets and "pass" the CloudFormation role (`iam:PassRole`).
+* **CloudFormation Role**: IAM role which allows the CloudFormation service principal to deploy stacks into the environment (this role usually has
+  administrative privileges).
+* **Deployment Role**: IAM role which allows anyone from the deployment account to create, update and describe CloudFormation change sets and "pass"
+  the CloudFormation role (`iam:PassRole`).
 
 To accommodate these requirements we will make the following changes to how `cdk bootstrap` works:
 
@@ -225,34 +295,46 @@ To accommodate these requirements we will make the following changes to how `cdk
 2. Use explicit convention-based physical names for all resources.
 3. Allow specifying a list of *trusted accounts* that can deploy to this account.
 4. Allow specifying the managed policy to use for the deployment role (mostly it will be the administrator managed policy).
-5. Allow specifying an optional qualifier for the physical names of all resources to address bucket hijacking concerns and allow multiple bootstraps to the same environment for whatever reason.
+5. Allow specifying an optional qualifier for the physical names of all resources to address bucket hijacking concerns and allow multiple bootstraps
+   to the same environment for whatever reason.
 
-**Bootstrapping at Scale**
+### Bootstrapping at Scale
 
-Since organizations may have to bootstrap thousands of accounts, we need to make sure we allow users to leverage "account stamping" tools such as [AWS CloudFormation StackSets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/what-is-cfnstacksets.html) and [AWS Control Tower](https://aws.amazon.com/controltower/). All of these tools are based on automatically and reliably deploying a single AWS CloudFormation template to multiple accounts across an organization.
+Since organizations may have to bootstrap thousands of accounts, we need to make sure we allow users to leverage "account stamping" tools such as [AWS
+CloudFormation StackSets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/what-is-cfnstacksets.html) and [AWS Control
+Tower](https://aws.amazon.com/controltower/). All of these tools are based on automatically and reliably deploying a single AWS CloudFormation
+template to multiple accounts across an organization.
 
 To make sure users can use these tools for bootstrapping, we will take the following requirements:
 
 - Bootstrapping "logic" MUST be expressible through an AWS CloudFormation template.
-- Bootstrapping MUST be self-contained within an environment (account+region). We can't rely on the bootstrapping process to work across accounts or regions.
-- Bootstrapping template size cannot exceed 50KiB so it can be deployed through the `TemplateBody` option of the CloudFormation `CreateStack` API (and not require an S3 bucket).
+- Bootstrapping MUST be self-contained within an environment (account+region). We can't rely on the bootstrapping process to work across accounts or
+  regions.
+- Bootstrapping template size cannot exceed 50KiB so it can be deployed through the `TemplateBody` option of the CloudFormation `CreateStack` API (and
+  not require an S3 bucket).
 - Bootstrapping templates cannot rely on any other asset such as files on S3 or docker images.
 
-**Resource Names**
+### Resource Names
 
-We need to be able to synthesize asset locations into the templates for consumption and publishing. We also need to be able to assume a role in order to be able to publish to the environment.
+We need to be able to synthesize asset locations into the templates for consumption and publishing. We also need to be able to assume a role in order
+to be able to publish to the environment.
 
 This means that we cannot rely on CloudFormation physical name generation since it requires accessing the account in order to resolve these names.
 
-We will employ a naming convention which encodes `account`, `region` and an optional `qualifier` (such as `cdk-account-region[-qualifier]-xxxx`). This is because not all AWS resource names are environment-local: IAM roles are account-wide and S3 buckets are global.
+We will employ a naming convention which encodes `account`, `region` and an optional `qualifier` (such as `cdk-account-region[-qualifier]-xxxx`). This
+is because not all AWS resource names are environment-local: IAM roles are account-wide and S3 buckets are global.
 
-It is important that we do not rely on hashing or parsing account and region in order to be able to support account stamping tools like CloudFormation StackSets and Control Tower (in which case "account" resolves to `{ "Ref": "AWS::AccountId" }`, etc.
+It is important that we do not rely on hashing or parsing account and region in order to be able to support account stamping tools like CloudFormation
+StackSets and Control Tower (in which case "account" resolves to `{ "Ref": "AWS::AccountId" }`, etc.
 
-In order to address the risk of S3 bucket hijacking, we need to be able to support an optional `qualifier` postfix. This means that we need to allow users to specify this qualifier when they define the Stack's `env`. Perhaps we need to encode this into `aws://account/region[/qualifier]`
+In order to address the risk of S3 bucket hijacking, we need to be able to support an optional `qualifier` postfix. This means that we need to allow
+users to specify this qualifier when they define the Stack's `env`. Perhaps we need to encode this into `aws://account/region[/qualifier]`
 
-> **Alternative considered**: one way to implement environment-specific name-spacing would have been to export the bootstrapping resources through a CloudFormation Export and then reference them using Fn::ImportValue. This would have worked for templates, but means that we would need a way to resolve import values during publishing as well (and as a result also Fn::Join, etc).
+> **Alternative considered**: one way to implement environment-specific name-spacing would have been to export the bootstrapping resources through a
+> CloudFormation Export and then reference them using Fn::ImportValue. This would have worked for templates, but means that we would need a way to
+> resolve import values during publishing as well (and as a result also Fn::Join, etc).
 
-**User Interface**
+### User Interface
 
 This is the proposed API for `cdk-bootstrap`:
 
@@ -262,7 +344,8 @@ WARNING: any principal from <ACCOUNT_ID> will have administrative access to the 
 Please confirm (Y/N):
 ```
 
-We should consider allowing users to specify a profile map that will allow bootstrapping multiple environments at the same time, but this can easily be achieved through a shell script:
+We should consider allowing users to specify a profile map that will allow bootstrapping multiple environments at the same time, but this can easily
+be achieved through a shell script:
 
 ```bash
 #!/bin/sh
@@ -272,26 +355,47 @@ cdk bootstrap --yes --profile prod-eu aws://222222222222/eu-west-2 --trust-accou
 
 ## Mutation
 
-Deployment of complex cloud application often involves a business-specific process which includes rolling out the app throughout multiple deployment phases and environments. This means that there is strong coupling between the structure of the application and the structure of its deployment pipeline. To enable users to represent this relationship naturally in their code, the CDK should support defining the app's deployment infrastructure as part of the CDK app.
+Deployment of complex cloud application often involves a business-specific process which includes rolling out the app throughout multiple deployment
+phases and environments. This means that there is strong coupling between the structure of the application and the structure of its deployment
+pipeline. To enable users to represent this relationship naturally in their code, the CDK should support defining the app's deployment infrastructure
+as part of the CDK app.
 
-Therefore, we recommend that all resources needed for the deployment pipeline are defined as part of the CDK app itself in one or more stacks. After synthesis, the cloud assembly will include a set of CloudFormation templates for the pipeline stack(s).
+Therefore, we recommend that all resources needed for the deployment pipeline are defined as part of the CDK app itself in one or more stacks. After
+synthesis, the cloud assembly will include a set of CloudFormation templates for the pipeline stack(s).
 
-We can't begin to deploy an app before we provision and update the required the deployment resources based on the structure of the app. This is the purpose of the "**mutation**" stage.
+We can't begin to deploy an app before we provision and update the required the deployment resources based on the structure of the app. This is the
+purpose of the "**mutation**" stage.
 
-The initial creation of the pipeline will be performed manually using `cdk deploy pipeline-main` (where `pipeline-main` is name of the main pipeline stack for example), but from that point forward, any changes to the pipeline will be done by pushing a commit into the repo, and letting the pipeline pick it up.
+The initial creation of the pipeline will be performed manually using `cdk deploy pipeline-main` (where `pipeline-main` is name of the main pipeline
+stack for example), but from that point forward, any changes to the pipeline will be done by pushing a commit into the repo, and letting the pipeline
+pick it up.
 
-For example, if we use CodePipeline for deploying an app to multiple environments, the deployment infrastructure requires a central pipeline stack, which contains the pipeline itself, it's artifacts bucket and other related resources such as CodeBuild projects. It will also require a stack in each region that includes a CodePipeline regional replication bucket (and key). See [cross-region support](https://docs.aws.amazon.com/codepipeline/latest/userguide/actions-create-cross-region.html) in the CodePipeline User Guide.
+For example, if we use CodePipeline for deploying an app to multiple environments, the deployment infrastructure requires a central pipeline stack,
+which contains the pipeline itself, it's artifacts bucket and other related resources such as CodeBuild projects. It will also require a stack in each
+region that includes a CodePipeline regional replication bucket (and key). See [cross-region
+support](https://docs.aws.amazon.com/codepipeline/latest/userguide/actions-create-cross-region.html) in the CodePipeline User Guide.
 
-In CodePipeline, we will implement self-mutation using a pre-configured CodeBuild action which runs `cdk deploy "pipeline-*"`. This will deploy all stacks that begin with the `pipeline-` prefix. These stacks can be deployed to any bootstrapped environment since `cdk deploy` can assume the deployment role.
+In CodePipeline, we will implement self-mutation using a pre-configured CodeBuild action which runs `cdk deploy "pipeline-*"`. This will deploy all
+stacks that begin with the `pipeline-` prefix. These stacks can be deployed to any bootstrapped environment since `cdk deploy` can assume the
+deployment role.
 
-To mitigate the security risk, `cdk deploy pipeline-*` should run against a synthesized cloud assembly (from the build step) and not against the executable app, and should also prohibit the use of docker assets. These are the two elements where user code is executed and must not be done in an environment with administrative privileges. The mutation CodeBuild action will not be customizable to ensure that users don't accidentally allow it to execute arbitrary code.
+To mitigate the security risk, `cdk deploy pipeline-*` should run against a synthesized cloud assembly (from the build step) and not against the
+executable app, and should also prohibit the use of docker assets. These are the two elements where user code is executed and must not be done in an
+environment with administrative privileges. The mutation CodeBuild action will not be customizable to ensure that users don't accidentally allow it to
+execute arbitrary code.
 
-> Alternative Considered: We initially considered leveraging the bootstrapping process in order to provision cross-regional replication resources for CodePipeline but: (a) this is very specific to CodePipeline and not relevant to other deployment systems (e.g. Travis, GitHub Actions); and (b) it will require the bootstrapping process to span more than a single environment. In order to allow users to use "account stamping" tools like Stack Sets or Landing Zone, we decided that the bootstrapping process will be as simple as possible (== a single CloudFormation template). 
-> The trade-off is that for the CodePipeline resources, we will use `cdk deploy pipeline-*`, and so we can encode all this within the CDK. In fact cross account/region is actually already supported in the CDK and will automatically define all these stacks and region for you, so it should already "Just Work".
+> Alternative Considered: We initially considered leveraging the bootstrapping process in order to provision cross-regional replication resources for
+> CodePipeline but: (a) this is very specific to CodePipeline and not relevant to other deployment systems (e.g. Travis, GitHub Actions); and (b) it
+> will require the bootstrapping process to span more than a single environment. In order to allow users to use "account stamping" tools like Stack
+> Sets or Landing Zone, we decided that the bootstrapping process will be as simple as possible (== a single CloudFormation template).  The trade-off
+> is that for the CodePipeline resources, we will use `cdk deploy pipeline-*`, and so we can encode all this within the CDK. In fact cross
+> account/region is actually already supported in the CDK and will automatically define all these stacks and region for you, so it should already
+> "Just Work".
 
 ## Publishing
 
-The [`cdk-assets`](./cdk-assets.md) tool is responsible for _packaging_ and _publishing_ application assets to "**asset stores**" in AWS environments so they can be consumed by stacks deployed to these environments.
+The [`cdk-assets`](./cdk-assets.md) tool is responsible for _packaging_ and _publishing_ application assets to "**asset stores**" in AWS environments
+so they can be consumed by stacks deployed to these environments.
 
 See the [cdk-assets specification](./cdk-assets.md) for additional details.
 
@@ -301,42 +405,60 @@ cdk-assets publish cdk.out [ASSET-ID,ASSET-ID,...]
 
 The input is the *cloud assembly* (`cdk.out`), which includes an asset manifest `assets.json`:
 
-The manifest is synthesized by the app and, for each asset (identified by their source hash) includes the `source` information (within the cloud assembly) and as set of `destinations` with a list of locations into which the asset should be published. The idea is that this manifest is all the information the publish needs.
+The manifest is synthesized by the app and, for each asset (identified by their source hash) includes the `source` information (within the cloud
+assembly) and as set of `destinations` with a list of locations into which the asset should be published. The idea is that this manifest is all the
+information the publish needs.
 
-A list of asset IDs (source hashes) can also be included in order to only publish a subset of the assets. This can be used to implement concurrent publishing of assets (e.g. through CodePipeline).
+A list of asset IDs (source hashes) can also be included in order to only publish a subset of the assets. This can be used to implement concurrent
+publishing of assets (e.g. through CodePipeline).
 
 Then, for each asset, cdk-assets will perform the following operation:
 
 1. Assume the **publishing IAM role** in the target environment.
 2. Check if the asset is already published to this location. Assets are identified by their source hash. If it is, skip.
-3. If the asset doesn’t exists locally (e.g. docker image already exists, zip file already exists in local cache), package (docker build, zip directory).
+3. If the asset doesn’t exists locally (e.g. docker image already exists, zip file already exists in local cache), package (docker build, zip
+   directory).
 4. Publish the asset to the target location.
 
-In order for the publish to be able to execute `docker build`, this command must be executed in an environment that has docker available (in CodeBuild this means the project must be "privileged").
+In order for the publish to be able to execute `docker build`, this command must be executed in an environment that has docker available (in CodeBuild
+this means the project must be "privileged").
 
-[Caching of docker layers](https://docs.aws.amazon.com/codebuild/latest/userguide/build-caching.html#caching-local) is supported by CodeBuild and therefore `--ci` feature we have today in the CDK which pulls the `latest` tag of images before docker builds is not required. Furthermore, since images will now be identified only by their source hash (and not by their construct node ID) means that it will be impossible to pull a "latest" version.
+[Caching of docker layers](https://docs.aws.amazon.com/codebuild/latest/userguide/build-caching.html#caching-local) is supported by CodeBuild and
+therefore `--ci` feature we have today in the CDK which pulls the `latest` tag of images before docker builds is not required. Furthermore, since
+images will now be identified only by their source hash (and not by their construct node ID) means that it will be impossible to pull a "latest"
+version.
 
-**Templates as Assets**
+### Templates as Assets
 
-Some deployment systems (e.g. the CDK CLI and other systems we explored) require that CloudFormation templates will be uploaded an S3 location before they can be deployed (this is done automatically in CodePipeline). Due to S3 eventual consistency, these files must be immutable, so we need to upload a new template file every time the template changes.
+Some deployment systems (e.g. the CDK CLI and other systems we explored) require that CloudFormation templates will be uploaded an S3 location before
+they can be deployed (this is done automatically in CodePipeline). Due to S3 eventual consistency, these files must be immutable, so we need to upload
+a new template file every time the template changes.
 
-To that end, we will treat all CloudFormation templates in the assembly like any other asset. They will be identified by their source hash (the hash of the template) and uploaded to the asset store in the environment in which they are expected to be deployed, like any other file asset.
+To that end, we will treat all CloudFormation templates in the assembly like any other asset. They will be identified by their source hash (the hash
+of the template) and uploaded to the asset store in the environment in which they are expected to be deployed, like any other file asset.
 
 ## Deployment
 
-At this point, all assets are published to asset stores in their target environments, so we can simply use standard CloudFormation deployment tools to deploy templates from the cloud assembly. Any references to assets were already resolved during synthesis.
+At this point, all assets are published to asset stores in their target environments, so we can simply use standard CloudFormation deployment tools to
+deploy templates from the cloud assembly. Any references to assets were already resolved during synthesis.
 
 To deploy a stack to an environment, the deployment will need to:
 
-1. Assume the **Deployment IAM Role** from the target environment. The deployment IAM role is encoded inside the cloud assembly. By default the name of the role is rendered by `core.Stack` based on the conventions of the bootstrapping template, but users are able to override this behavior if their environments used custom bootstrapping.
+1. Assume the **Deployment IAM Role** from the target environment. The deployment IAM role is encoded inside the cloud assembly. By default the name
+   of the role is rendered by `core.Stack` based on the conventions of the bootstrapping template, but users are able to override this behavior if
+   their environments used custom bootstrapping.
 2. Create a CloudFormation change-set for the stack.
-3. Execute the change-set by requesting CloudFormation to assume the administrative **CloudFormation IAM Role** (again, role is encoded in the cloud assembly).
+3. Execute the change-set by requesting CloudFormation to assume the administrative **CloudFormation IAM Role** (again, role is encoded in the cloud
+   assembly).
 
-> This step intentionally uses the most standard CloudFormation deployment actions. This means that users will be able to implement custom flows that leverages these building blocks in any way they need. For example, they can incorporate a manual approval step between changeset creation and execution.
+> This step intentionally uses the most standard CloudFormation deployment actions. This means that users will be able to implement custom flows that
+> leverages these building blocks in any way they need. For example, they can incorporate a manual approval step between changeset creation and
+> execution.
 
 ## Walkthrough
 
-In this section we will walk through the process of deploying a complex CDK app and how each one of the components in the toolchain is used within the workflow.
+In this section we will walk through the process of deploying a complex CDK app and how each one of the components in the toolchain is used within the
+workflow.
 
 ### Bootstrapping
 
@@ -377,7 +499,8 @@ The bootstrapping process will create the following resources:
   * `aws-cdk-deploy-3333333333EU-eu-west-2`: IAM role for deployment (assumable by 111111111DEP), with pass-role to the CloudFormation role
   * `aws-cdk-admin-3333333333EU-eu-west-2`: IAM role for CloudFormation (assumable by the CloudFormation service principal)
 
-Notice that all bootstrapping resources have conventional physical names so asset locations can be resolved during synthesis without needing to access the accounts.
+Notice that all bootstrapping resources have conventional physical names so asset locations can be resolved during synthesis without needing to access
+the accounts.
 
 ### Source
 
@@ -385,11 +508,13 @@ This section describes the sample app we will use for our walkthrough in order t
 
 Our app needs to be deployed to two geographies: US (in us-east-1) and EU (in eu-west-2).
 
-In each geography, we will split our app into two stacks: one that includes the VPC resources (`vpc-us` and `vpc-eu`) and the other that includes the service resources (`service-us` and `service-eu`). This is just an example of course, apps should be able to define any layout they desire.
+In each geography, we will split our app into two stacks: one that includes the VPC resources (`vpc-us` and `vpc-eu`) and the other that includes the
+service resources (`service-us` and `service-eu`). This is just an example of course, apps should be able to define any layout they desire.
 
 The service stack will use two assets: one docker image created from a Dockerfile in our project and one zip file created from a directory.
 
-Deployment resources (pipeline, buckets, etc) will be defined in a separate set of stacks (`pipeline-main`, `pipeline-us-east-1` and `pipeline-eu-west-2`). The pipeline has the following stages:
+Deployment resources (pipeline, buckets, etc) will be defined in a separate set of stacks (`pipeline-main`, `pipeline-us-east-1` and
+`pipeline-eu-west-2`). The pipeline has the following stages:
 
 1. Source: monitors a git repository and kicks off the pipeline.
 2. Build: a CodeBuild action which compiles the app and invokes `cdk synth`. The output artifact is `cdk.out`.
@@ -403,7 +528,8 @@ NOTES:
 * The "Build" stage is defined by the user and expected to always have `cdk.out` as the output artifact (by convention).
 * The "Mutate" and "Publish" stage will be provided as ready-made building blocks
 * The order and structure of the "Deployment" stages are just an example. Users may choose the orchestration they need.
-* The AWS CodePipeline module in the CDK will automatically define all auxiliary stacks required for the pipeline based on the actual structure (`pipeline-REGION`).
+* The AWS CodePipeline module in the CDK will automatically define all auxiliary stacks required for the pipeline based on the actual structure
+  (`pipeline-REGION`).
 
 ### Synthesis
 
@@ -419,7 +545,8 @@ After the app is compiled, `cdk synth` will produce a `cdk.out` directory (cloud
 8. `service-us.template.json`: service stack for the US deployment
 9. `service-eu.template.json`: service stack for the EU deployment
 
-The `manifest.json` file will include an entry for each stack defined above (like today), but each stack will also include the IAM roles to assume if you wish to deploy this stack:
+The `manifest.json` file will include an entry for each stack defined above (like today), but each stack will also include the IAM roles to assume if
+you wish to deploy this stack:
 
 ```json
 {
@@ -543,29 +670,37 @@ The `assets.json` file will look like this:
 }
 ```
 
-It lists the two assets (one file asset and one image asset) and, for each, it lists the publishing locations which include repository, key and publishing IAM role to assume.
+It lists the two assets (one file asset and one image asset) and, for each, it lists the publishing locations which include repository, key and
+publishing IAM role to assume.
 
 ### Pipeline Initialization
 
-At this point we have a bunch of bootstrapped environments and a local `cdk.out` directory. In order to deploy our self-mutating CI/CD pipeline for the app, we need to perform a single, one-off, manual operation:
+At this point we have a bunch of bootstrapped environments and a local `cdk.out` directory. In order to deploy our self-mutating CI/CD pipeline for
+the app, we need to perform a single, one-off, manual operation:
 
 ```console
 $ cdk deploy "pipeline-*"
 ```
 
-Running this manually will deploy our pipeline which monitors our source control. From now on, any chances to our pipeline will be done by pushing commits into our source repository and not through the CDK CLI.
+Running this manually will deploy our pipeline which monitors our source control. From now on, any chances to our pipeline will be done by pushing
+commits into our source repository and not through the CDK CLI.
 
 ### Mutation
 
 The first stage in our pipeline is the mutation stage. This stage will include a single CodeBuild action that will simply execute: `cdk deploy pipeline-*`.
 
-This will update all the stacks with names that begin with "pipeline-". Namely, it includes the pipeline stack itself, and the auxiliary stacks that include the pipeline's regional replication buckets. Since we are using `cdk deploy` here, we can technically deploy any stack to any environment in this stage because `cdk deploy` can assume the deployment role in any of the environments which trust the deployment account.
+This will update all the stacks with names that begin with "pipeline-". Namely, it includes the pipeline stack itself, and the auxiliary stacks that
+include the pipeline's regional replication buckets. Since we are using `cdk deploy` here, we can technically deploy any stack to any environment in
+this stage because `cdk deploy` can assume the deployment role in any of the environments which trust the deployment account.
 
-> In the [CodePipeline Cross Account Reference Architecture](https://github.com/awslabs/aws-refarch-cross-account-pipeline) the "deployment account" is known as the "tools account".
+> In the [CodePipeline Cross Account Reference Architecture](https://github.com/awslabs/aws-refarch-cross-account-pipeline) the "deployment account"
+> is known as the "tools account".
 
-Notice that this stage happens **before** the publish stage. This is because the structure of the publish stage is dependent on which assets the app uses (we synthesize an action per asset for maximal parallelism), so we want to make sure the pipeline will be updated before publishing.
+Notice that this stage happens **before** the publish stage. This is because the structure of the publish stage is dependent on which assets the app
+uses (we synthesize an action per asset for maximal parallelism), so we want to make sure the pipeline will be updated before publishing.
 
-> NOTE: if there is a constraint that does not allow the pipeline to be updated before publishing, it simply means that we have to publish all assets from a single action (`cdk-assets publish cdk.out`).
+> NOTE: if there is a constraint that does not allow the pipeline to be updated before publishing, it simply means that we have to publish all assets
+> from a single action (`cdk-assets publish cdk.out`).
 
 In our example, there are 3 pipeline stacks:
 
@@ -579,9 +714,12 @@ Once we deploy these stacks, our pipeline will be ready to deploy the rest of ou
 
 The next stage in the process is the publishing stage.
 
-In our example, this stage will consist of two CodeBuild actions that will run the following commands concurrently. These command will package & upload the asset to all the environments. It will consult `assets.json` to determine the exact location into which to publish each asset and which cross-account role to assume.
+In our example, this stage will consist of two CodeBuild actions that will run the following commands concurrently. These command will package &
+upload the asset to all the environments. It will consult `assets.json` to determine the exact location into which to publish each asset and which
+cross-account role to assume.
 
-> The CodePipeline stage that includes all the asset publishing actions will be automatically generated based on the application structure. This means that any new assets added to the app will automatically appear in this pipeline stage as new CodeBuild actions.
+> The CodePipeline stage that includes all the asset publishing actions will be automatically generated based on the application structure. This means
+> that any new assets added to the app will automatically appear in this pipeline stage as new CodeBuild actions.
 
 The first action will run this command:
 
@@ -589,7 +727,8 @@ The first action will run this command:
 cdk-assets publish cdk.out d31ca1aef8d1b68217852e7aea70b1e857d107b47637d5160f9f9a1b24882d2a
 ```
 
-This will build the docker image from `cdk.out/my-image` using `CustomDockerFile` as a dockerfile. Then, it will assume the roles in the destinations specified in `assets.json` and push the image to the specified ECR locations.
+This will build the docker image from `cdk.out/my-image` using `CustomDockerFile` as a dockerfile. Then, it will assume the roles in the destinations
+specified in `assets.json` and push the image to the specified ECR locations.
 
 The second action will run this command:
 
@@ -597,49 +736,66 @@ The second action will run this command:
 cdk-assets publish cdk.out a0bae29e7b47044a66819606c65d26a92b1e844f4b3124a5539efc0167a09e57
 ```
 
-This will create a zip archive from the files under `asset.a0bae29e7b47044a66819606c65d26a92b1e844f4b3124a5539efc0167a09e57`, and then will assume the roles and upload the file to the destination S3 locations.
+This will create a zip archive from the files under `asset.a0bae29e7b47044a66819606c65d26a92b1e844f4b3124a5539efc0167a09e57`, and then will assume the
+roles and upload the file to the destination S3 locations.
 
 ### Deployment
 
-Once publishing is complete, we can commence deployment. Deployment can happen at any desired order and use the standard CloudFormation deployment actions.
+Once publishing is complete, we can commence deployment. Deployment can happen at any desired order and use the standard CloudFormation deployment
+actions.
 
-Each action will be responsible to deploy a single stack to a specific environment. The input artifact will be the cloud assembly, and the template file name will be the template
+Each action will be responsible to deploy a single stack to a specific environment. The input artifact will be the cloud assembly, and the template
+file name will be the template
 
-In our example, we decided to first deploy the VPC stack to all geographies and then deploy the service stack, so we will have two deployment stages, each one with two CloudFormation deployment actions.
+In our example, we decided to first deploy the VPC stack to all geographies and then deploy the service stack, so we will have two deployment stages,
+each one with two CloudFormation deployment actions.
 
 All actions will use `cdk.out` as their input artifact, with the specified template name, account, region, deploy and CloudFormation IAM roles.
 
-CodePipeline will use the regional replication buckets to transfer cdk.out to the destination regions and then assume the deployment role that will invoke the CloudFormation API, passing it the CloudFormation role.
+CodePipeline will use the regional replication buckets to transfer cdk.out to the destination regions and then assume the deployment role that will
+invoke the CloudFormation API, passing it the CloudFormation role.
 
 That's it basically.
 
 ## Compatibility Plan
 
-This section describes how we plan to implement this new model, while still supporting old CLIs, apps written with old frameworks and old bootstrap environments.
+This section describes how we plan to implement this new model, while still supporting old CLIs, apps written with old frameworks and old bootstrap
+environments.
 
 This design requires disruptive changes to the following components:
 
-- **Bootstrap Stack**: the contents of the environment's bootstrap stack has changed. It now includes additional resources like an ECR repository and IAM role, and also uses conventional physical names.
-- **Assets (Framework)**: currently each asset synthesizes a set of CloudFormation parameter that is then assigned by the CLI during deployment, and assets are described as metadata in the cloud assembly manifest. This design stipulates that assets will always be published to well-known locations (based on the bootstrap stack conventions) and described in the `assets.json` manifest which is consumed by `cdk-assets`.
-- **Publishing (CLI)**: currently the CLI conflates both asset publishing and deployment into a single step. This design stipulates that `cdk-assets` manages all asset publishing and the CLI is only responsible for deployment.
-- **AdoptedRepository**: The new asset mechanism does not require Docker image assets to be backed by `AdoptedRepository` since the ECR repository in the new bootstrap stack will allow anyone to read from it.
-- **Deployment Roles**: In the new mode, the cloud assembly manifest also includes IAM roles for deployment. These only exist in the new model, and should cause the CLI to assume these roles during depoyment.
+- **Bootstrap Stack**: the contents of the environment's bootstrap stack has changed. It now includes additional resources like an ECR repository and
+  IAM role, and also uses conventional physical names.
+- **Assets (Framework)**: currently each asset synthesizes a set of CloudFormation parameter that is then assigned by the CLI during deployment, and
+  assets are described as metadata in the cloud assembly manifest. This design stipulates that assets will always be published to well-known locations
+  (based on the bootstrap stack conventions) and described in the `assets.json` manifest which is consumed by `cdk-assets`.
+- **Publishing (CLI)**: currently the CLI conflates both asset publishing and deployment into a single step. This design stipulates that `cdk-assets`
+  manages all asset publishing and the CLI is only responsible for deployment.
+- **AdoptedRepository**: The new asset mechanism does not require Docker image assets to be backed by `AdoptedRepository` since the ECR repository in
+  the new bootstrap stack will allow anyone to read from it.
+- **Deployment Roles**: In the new mode, the cloud assembly manifest also includes IAM roles for deployment. These only exist in the new model, and
+  should cause the CLI to assume these roles during depoyment.
 
 ### Goal
 
-Existing applications should continue to seamlessly work in any combination of CLI/framework without any forced modification when suppot for these new capabilities is introduced.
+Existing applications should continue to seamlessly work in any combination of CLI/framework without any forced modification when suppot for these new
+capabilities is introduced.
 
-Obvsiouly, if users wish to leverage the new CDK continuous delivery capabilities, they will have to upgrade all three components (bootstrap stack, framework, CLI). It's important that their experience will be guided (i.e. they will be promoted exactly what they need to do and not simply get cryptic error messages).
+Obvsiouly, if users wish to leverage the new CDK continuous delivery capabilities, they will have to upgrade all three components (bootstrap stack,
+framework, CLI). It's important that their experience will be guided (i.e. they will be promoted exactly what they need to do and not simply get
+cryptic error messages).
 
 ### Approach
 
-The main implication is that both CLI and framework should continue to support the "legacy mode" which controls all relevant behavior: asset synthesis (including `AdoptedRepository`), deployment roles and any other aspect described in this design.
+The main implication is that both CLI and framework should continue to support the "legacy mode" which controls all relevant behavior: asset synthesis
+(including `AdoptedRepository`), deployment roles and any other aspect described in this design.
 
-The following table describes the desired behavior for each combination of CLI version, framework version and whether this is an existing app or a new app (the result of `cdk init` from a new CLI):
+The following table describes the desired behavior for each combination of CLI version, framework version and whether this is an existing app or a new
+app (the result of `cdk init` from a new CLI):
 
-| #  |      | CLI  | Framework | Bootstrap | App | Mode | Comments       
+| #  |      | CLI  | Framework | Bootstrap | App | Mode | Comments
 |----|------|------|-----------|-----------|-----|------|----------------------
-| 0  | 0000 | OLD  | OLD       | OLD       | OLD | 1.0  | No change     
+| 0  | 0000 | OLD  | OLD       | OLD       | OLD | 1.0  | No change
 | 1  | 0001 | OLD  | OLD       | OLD       | NEW | 1.0  | App created with old CLI
 | 2  | 0010 | OLD  | OLD       | NEW       | OLD | 1.0  | "Run `cdk bootstrap`"
 | 3  | 0011 | OLD  | OLD       | NEW       | NEW | 1.0  | new bootstrap stack is not detectable
@@ -658,14 +814,22 @@ The following table describes the desired behavior for each combination of CLI v
 
 ### Requirements
 
-The CLI must auto-detect the assembly format version of the synthesized app based on heuristics `assets.json` or asset metadata in manifest (perhaps we will just bump the assembly manifest version number). Based on this version it will execute either the legacy (1.0) code path or the new code path. If the old code path is required, the old bootstrap behavior will be expected. If the bootstrap stack
+The CLI must auto-detect the assembly format version of the synthesized app based on heuristics `assets.json` or asset metadata in manifest (perhaps
+we will just bump the assembly manifest version number). Based on this version it will execute either the legacy (1.0) code path or the new code path.
+If the old code path is required, the old bootstrap behavior will be expected. If the bootstrap stack
 
 The framework will use the CLI version information passed in through environment variable to detect an old CLI.
 
-A new feature flag `cloud-assembly-version` will be used to determine the cloud assembly format version the framework operates in. This flag will front all relevant code paths.
+A new feature flag `cloud-assembly-version` will be used to determine the cloud assembly format version the framework operates in. This flag will
+front all relevant code paths.
 
-In order to enable case #6 (new CLI + framework with old app), the default for `cloud-assembly-version` will be `1.0` (legacy). This means old apps that upgrade both CLI and framework to new version will continue to function without any change. If old apps wishes to use the new behavior, they will have to explicitly specify `cloud-assembly-version` in their `cdk.json` (or code).
+In order to enable case #6 (new CLI + framework with old app), the default for `cloud-assembly-version` will be `1.0` (legacy). This means old apps
+that upgrade both CLI and framework to new version will continue to function without any change. If old apps wishes to use the new behavior, they will
+have to explicitly specify `cloud-assembly-version` in their `cdk.json` (or code).
 
-However, we still want new CDK apps created using `cdk init` to use the new behavior (case #9). To that end, when `cdk init` will be executed from a new CLI, the `cdk.json` it will generate will pass in `cloud-assembly-version: 2.0`. This basically means that new apps will automatically be opted-in to this new behavior.
+However, we still want new CDK apps created using `cdk init` to use the new behavior (case #9). To that end, when `cdk init` will be executed from a
+new CLI, the `cdk.json` it will generate will pass in `cloud-assembly-version: 2.0`. This basically means that new apps will automatically be opted-in
+to this new behavior.
 
-If old CLI is used and the app is configured to use 2.0 (#3), an error will be raised (we could technically fall back to 1.0 but there is probably no sufficient value).
+If old CLI is used and the app is configured to use 2.0 (#3), an error will be raised (we could technically fall back to 1.0 but there is probably no
+sufficient value).

--- a/text/0055-feature-flags.md
+++ b/text/0055-feature-flags.md
@@ -65,9 +65,8 @@ without risking breakage in other unexpected areas.
 
 # Detailed Design
 
-
 Context keys for feature flags will be listed in `cx-api/lib/features.ts` and
-will take the form: `<module>:<feature>`. 
+will take the form: `<module>:<feature>`.
 
 For example:
 
@@ -158,7 +157,7 @@ that specifies the CDK version which created the project, but this means that
 users won't have the ability to pick and choose which capabilities they want to
 enable in case they need them but don't want to take the risk of unexpected
 changes.
- 
+
 The downside of the fine-grained approach is that it could result in a "blowing
 up" new `cdk.json` files in case there will be many new breaking capabilities
 between major releases. But this is hypothetical and even if this list ends up
@@ -194,15 +193,17 @@ contribution guide and will involve the following steps:
    through `cdk init`.
 5. In your PR title (which goes into CHANGELOG), add a `(behind feature flag)`
    suffix. e.g:
+
     ```
     fix(core): impossible to use the same physical stack name for two stacks (under feature flag)
     ```
+
 5. Under `BREAKING CHANGES`, add a prefix `(under feature flag)` and the name of
    the flag in the postfix. For example:
 
     ```
-    BREAKING CHANGE: (under feature flag) template file names for new projects created 
-    through "cdk init" will use the template artifact ID instead of the physical stack 
+    BREAKING CHANGE: (under feature flag) template file names for new projects created
+    through "cdk init" will use the template artifact ID instead of the physical stack
     name to enable  multiple stacks to use the same name (feature flag: @aws-cdk/core:enableStackNameDuplicates)
     ```
 
@@ -234,4 +235,3 @@ in the future (as well as any other idea of course):
 - Define a flag that will allow users to say "I want all feature up until a
   certain CDK version" (basically enables all features that were available when
   the version was releases).
-

--- a/text/0092-asset-publishing.md
+++ b/text/0092-asset-publishing.md
@@ -6,28 +6,44 @@ This document specifies the requirements for this tool derived from the [continu
 
 ## Assumptions
 
-* Similarly to any resource defined through code and managed through CloudFormation, we are not attempting to protect assets from manual tampering by users.
+* Similarly to any resource defined through code and managed through CloudFormation, we are not attempting to protect assets from manual tampering by
+  users.
 
 ## Asset Manifest
 
-The main input to `cdk-assets` is a JSON file called `assets.json` which includes a manifest of assets. 
+The main input to `cdk-assets` is a JSON file called `assets.json` which includes a manifest of assets.
 
-The manifest lists all assets and for each asset it describes the asset **source** (with instructions on how to package the asset if needed) and a list of **destinations**, which are locations into which this asset needs to be published.
+The manifest lists all assets and for each asset it describes the asset **source** (with instructions on how to package the asset if needed) and a
+list of **destinations**, which are locations into which this asset needs to be published.
 
 The main components of the assets manifest are:
 
-* **Types:** there are currently two supported types: files and docker images. Files are uploaded to an Amazon S3 bucket and docker images are pushed to an Amazon ECR repository.
+* **Types:** there are currently two supported types: files and docker images. Files are uploaded to an Amazon S3 bucket and docker images are pushed
+  to an Amazon ECR repository.
 
-* **Identifiers:** assets are identified throughout the system via a unique identifier (the key in the `files` and `images` map). This identifier is based on the sha256 of the source (the contents of the file or directory) and will change only if the source changes. It can be used for local caching and optimization purposes. For example, a zip of a directory can be stored in a local cache by this identifier to avoid duplicate work.
+* **Identifiers:** assets are identified throughout the system via a unique identifier (the key in the `files` and `images` map). This identifier is
+  based on the sha256 of the source (the contents of the file or directory) and will change only if the source changes. It can be used for local
+  caching and optimization purposes. For example, a zip of a directory can be stored in a local cache by this identifier to avoid duplicate work.
 
-* **Sources:** the `source` information for each asset defines the file or directory (relative to the directory of `assets.json`), and additional **packaging** instructions, such as whether to create a zip file from a directory (for file assets) or which options to pass to `docker build`.
+* **Sources:** the `source` information for each asset defines the file or directory (relative to the directory of `assets.json`), and additional
+  **packaging** instructions, such as whether to create a zip file from a directory (for file assets) or which options to pass to `docker build`.
 
-* **Destinations:** describe where the asset should be published. At a minimum, for file assets, it includes the S3 bucket and object key and for docker images it includes the repository and image names. A destination may also indicate that an IAM role must be assumed in order to support cross environment publishing. 
+* **Destinations:** describe where the asset should be published. At a minimum, for file assets, it includes the S3 bucket and object key and for
+  docker images it includes the repository and image names. A destination may also indicate that an IAM role must be assumed in order to support cross
+  environment publishing.
 
 NOTES:
 
-* **Denormalization:** destinations are intentionally denormalized in order to keep the logic of where assets are published at the application or framework level and not in this tool. For example, consider a deployment system which requires that all assets are always published to the same location, and then replicated through some other means to their actual consumption point. Alternatively, a user may have unique security requirements that will require certain assets to be stored in dedicated locations (e.g. with a specific key) and others in a different location, even if they all go to the same environment. Therefore, this tool should not take any assumptions on where assets should be published besides the exact instructions in this file.
-* **Environment-agnostic:** In order to allow assets to be used in environment-agnostic stacks, `assets.json` will support two simple substitutions `${AWS::AccountId}` and `${AWS::Region}` which will be replaced with the currently configured account/region (alternatively, we can also decide to support CloudFormation intrinsic functions and pseudo references). The "current" account and region will always refer to the one derived from the CLI configuration even if `assets.json` instructs to assume a role from a different account.
+* **Denormalization:** destinations are intentionally denormalized in order to keep the logic of where assets are published at the application or
+  framework level and not in this tool. For example, consider a deployment system which requires that all assets are always published to the same
+  location, and then replicated through some other means to their actual consumption point. Alternatively, a user may have unique security
+  requirements that will require certain assets to be stored in dedicated locations (e.g. with a specific key) and others in a different location,
+  even if they all go to the same environment. Therefore, this tool should not take any assumptions on where assets should be published besides the
+  exact instructions in this file.
+* **Environment-agnostic:** In order to allow assets to be used in environment-agnostic stacks, `assets.json` will support two simple substitutions
+  `${AWS::AccountId}` and `${AWS::Region}` which will be replaced with the currently configured account/region (alternatively, we can also decide to
+  support CloudFormation intrinsic functions and pseudo references). The "current" account and region will always refer to the one derived from the
+  CLI configuration even if `assets.json` instructs to assume a role from a different account.
 
 Here is the complete manifest file schema in typescript:
 
@@ -134,7 +150,8 @@ Example of `assets.json` with two assets: a docker image and a file asset. Both 
 
 ## API
 
-`cdk-assets` is designed as a stand-alone command line program and a library, so it can be integrated into other tools such as the CDK CLI or executed individually as a step in a CI/CD pipeline.
+`cdk-assets` is designed as a stand-alone command line program and a library, so it can be integrated into other tools such as the CDK CLI or executed
+individually as a step in a CI/CD pipeline.
 
 ### `publish`
 
@@ -145,7 +162,8 @@ cdk-assets publish DIR [ASSET-ID,ASSET-ID...]
 Packages and publishes assets to all destinations.
 
 * `DIR` is the directory from where to read `assets.json`, and which is used as the base directory for all file/directory references.
-* `ASSET-ID,...`: additional arguments represent asset identifiers to publish (default is to publish all assets). This can be used to implement concurrent publishing of assets (e.g. through CodePipeline).
+* `ASSET-ID,...`: additional arguments represent asset identifiers to publish (default is to publish all assets). This can be used to implement
+  concurrent publishing of assets (e.g. through CodePipeline).
 
 The `publish` command will do the following:
 
@@ -162,7 +180,8 @@ for each asset in manifest:
     publish to destination (upload/push)
 ```
 
-> When we execute this tool in a CodeBuild project, we should enable [local caching](https://docs.aws.amazon.com/codebuild/latest/userguide/build-caching.html#caching-local) of docker images as an optimization.
+> When we execute this tool in a CodeBuild project, we should enable [local
+> caching](https://docs.aws.amazon.com/codebuild/latest/userguide/build-caching.html#caching-local) of docker images as an optimization.
 
 Example (`cdk.out/assets.json` as above):
 
@@ -176,7 +195,7 @@ package  docker build --target=my-target --label=prod -f CustomDockerFile ./myim
 push     aws-cdk-images-2222222222US-us-east-1:d31ca1aef8d1b68217852e7aea70b1e857d107b47637d5160f9f9a1b24882d2a
 assume   arn:aws:iam::3333333333EU:role/aws-cdk-publish-3333333333EU-eu-west-2
 found    aws-cdk-images-3333333333EU-eu-west-2:d31ca1aef8d1b68217852e7aea70b1e857d107b47637d5160f9f9a1b24882d2a
-done     d31ca1aef8d1b68217852e7aea70b1e857d107b47637d5160f9f9a1b24882d2a    
+done     d31ca1aef8d1b68217852e7aea70b1e857d107b47637d5160f9f9a1b24882d2a
 --------------------------------------------------------------------------
 asset    a0bae29e7b47044a66819606c65d26a92b1e844f4b3124a5539efc0167a09e57
 found    s3://aws-cdk-files-2222222222US-us-east-1/a0bae29e7b47044a66819606c65d26a92b1e844f4b3124a5539efc0167a09e57.zip
@@ -190,9 +209,14 @@ done     a0bae29e7b47044a66819606c65d26a92b1e844f4b3124a5539efc0167a09e57
 
 The log above describes the following:
 
-The first asset to process is the docker image with id `d31ca1a...`. We first assume the role is the 2222US environment and check if the image exists in this ECR repository. Since it doesn't exist (`notfound`), we check if it exists in the local cache under the tag `d31ca1aef8d1b68217852e7aea70b1e857d107b47637d5160f9f9a1b24882d2a`. It doesn't so we build the docker image (`package`) and then push it. Then we assume the role from the 33333EU environment and find that the image is already in that ECR repository, so we just finish.
+The first asset to process is the docker image with id `d31ca1a...`. We first assume the role is the 2222US environment and check if the image exists
+in this ECR repository. Since it doesn't exist (`notfound`), we check if it exists in the local cache under the tag
+`d31ca1aef8d1b68217852e7aea70b1e857d107b47637d5160f9f9a1b24882d2a`. It doesn't so we build the docker image (`package`) and then push it. Then we
+assume the role from the 33333EU environment and find that the image is already in that ECR repository, so we just finish.
 
-The second asset is the file asset with id `a0bae...`. The first environment doesn't specify a role, so we just check if the file exists in the S3 bucket. It is, so we move to the next destination. We assume the role and check if the asset is in the s3 location. It is not (`notfound`), so we need to package and upload it. Before we package we check if it's cached locally and find that it is (`cached`), so no need to zip again, just `upload`.
+The second asset is the file asset with id `a0bae...`. The first environment doesn't specify a role, so we just check if the file exists in the S3
+bucket. It is, so we move to the next destination. We assume the role and check if the asset is in the s3 location. It is not (`notfound`), so we need
+to package and upload it. Before we package we check if it's cached locally and find that it is (`cached`), so no need to zip again, just `upload`.
 
 ### `ls`
 
@@ -214,9 +238,11 @@ This information is purely based on the contents of `assets.json`.
 
 ### Programmatic API
 
-The tool should expose a programmatic (library) API, so it can be integrated with other tools such as the AWS CLI and IDEs. The library should be jsii-compliant and released to all languages supported by the AWS CDK.
+The tool should expose a programmatic (library) API, so it can be integrated with other tools such as the AWS CLI and IDEs. The library should be
+jsii-compliant and released to all languages supported by the AWS CDK.
 
-Since the publishing process is highly asynchronous, the API should include the ability to subscribe to progress events in order to allow implementation of a rich user interface.
+Since the publishing process is highly asynchronous, the API should include the ability to subscribe to progress events in order to allow
+implementation of a rich user interface.
 
 Proposed API:
 
@@ -253,5 +279,7 @@ class Publish {
 ## Non-Functional Requirements
 
 * **test coverage**: codebase must have full unit test coverage and a set of integration tests that can be executed within a pipeline environment.
-* **minimal dependencies**: the tool should take the minimum amount of 3rd party dependencies in order to reduce attack surface and to simplify bundling for jsii.
-* **jsii**: the API must be jsii-complient, so it can be used programmatically from all supported languages. This means that all non-jsii dependencies must be bundled into the module.
+* **minimal dependencies**: the tool should take the minimum amount of 3rd party dependencies in order to reduce attack surface and to simplify
+  bundling for jsii.
+* **jsii**: the API must be jsii-complient, so it can be used programmatically from all supported languages. This means that all non-jsii dependencies
+  must be bundled into the module.

--- a/tools/linters/.gitignore
+++ b/tools/linters/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/tools/linters/markdownlint.json
+++ b/tools/linters/markdownlint.json
@@ -1,8 +1,17 @@
 {
   "blank_line": false,
+  "commands-show-output": false,
   "fenced-code-language": false,
   "line_length": {
     "line_length": 150
+  },
+  "no-duplicate-heading": {
+    "siblings_only": true
+  },
+  "no-inline-html": {
+    "allowed_elements": [
+      "span"
+    ]
   },
   "ol-prefix": false,
   "single-h1": false,

--- a/tools/linters/markdownlint.json
+++ b/tools/linters/markdownlint.json
@@ -2,6 +2,7 @@
   "blank_line": false,
   "commands-show-output": false,
   "fenced-code-language": false,
+  "first-line-h1": false,
   "line_length": {
     "line_length": 150
   },
@@ -10,8 +11,13 @@
   },
   "no-inline-html": {
     "allowed_elements": [
-      "span"
+      "span",
+      "details",
+      "summary"
     ]
+  },
+  "no-trailing-punctuation": {
+    "punctuation": ".,;:!。，；：！"
   },
   "ol-prefix": false,
   "single-h1": false,

--- a/tools/linters/package.json
+++ b/tools/linters/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "linters",
+  "version": "1.0.0",
+  "license": "ISC",
+  "dependencies": {
+    "markdownlint-cli": "^0.22.0"
+  }
+}

--- a/tools/rfc-render/render-rfc-table.js
+++ b/tools/rfc-render/render-rfc-table.js
@@ -49,7 +49,7 @@ async function render() {
     }
   }
 
-  lines.push('\#|Title|PR|Created By|Champion|Status');
+  lines.push('\\#|Title|PR|Created By|Champion|Status');
   lines.push('-|-----|--|----------|--------|------');
 
   for (const row of issues) {

--- a/tools/rfc-render/render-rfc-table.js
+++ b/tools/rfc-render/render-rfc-table.js
@@ -49,7 +49,7 @@ async function render() {
     }
   }
 
-  lines.push('#|Title|PR|Created By|Champion|Status');
+  lines.push('\#|Title|PR|Created By|Champion|Status');
   lines.push('-|-----|--|----------|--------|------');
 
   for (const row of issues) {


### PR DESCRIPTION
Use Github actions to run markdownlint for PRs. A reasonable set of
defaults are chosen and configured under `.markdownlint.json`.

Keeping the `.markdownlint.json` file in the root of the folder so that
it is picked up by VS Code markdownlint plugin by default.

Note, all changes to the markdown files are purely formatting to
conform with the markdown linter rules.

Motivations:
The main motivations is so that all RFCs meet a reasonable bar in terms
of consistency. The main violator is line width - unusually long lines
are hard to review and comment on in PRs. They also don't play very well
with text editors.

The added benefit is that some parts of markdown are flimsy such that
they need to be formatted in a particular way to be rendered correctly.
This will help users keep to that.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_
