### PR TITLE
fix: markdownlint is not actually catching lints

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -14,7 +14,5 @@ jobs:
           npm install --prefix tools/linters
       - name: run linter
         run: |
-          cd ./tools/linters
-          npx --no-install markdownlint -c markdownlint.json ../../*.md ../../text/**/*.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          find . -type f -name '*.md' -not -path '*/node_modules/*' -not -path '*/.github/*' |\
+            xargs -I'{}' ./tools/linters/node_modules/.bin/markdownlint -c tools/linters/markdownlint.json '{}'

--- a/text/0095-cognito-construct-library.md
+++ b/text/0095-cognito-construct-library.md
@@ -57,9 +57,9 @@ be prioritized based on customer requests and +1s.
   * Import using user pool name
   * Configure SES email actions.
   * ClientMetadata and ValidationData properties in User
-  * Support for Clients and HostedUI - https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-app-integration.html
-  * Identity providers - https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-identity-federation.html
-  * Advanced security features - https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-advanced-security.html
+  * Support for [Clients and HostedUI](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-app-integration.html)
+  * [Identity providers](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-identity-federation.html)
+  * [Advanced security features](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-advanced-security.html)
 * Identity Pool
   * External provider - Cognito. This requires CDK coverage of user pool clients (above). While it's available via the
     APIs and CloudFormation resources, it is [not listed in the
@@ -74,4 +74,3 @@ The following are out of scope of this document and are unlikely to be implement
 * Identity pool cognito sync. Reason:
   [Documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-sync.html) suggests the use of AWS
   AppSync instead.
-


### PR DESCRIPTION
It seems that Github actions don't support shell globbing, so
`markdownlint` was actually looking for files name `*.md` and `**/*.md`
which obviously don't exist.

Switching to `find` and `xargs` to enumerate the files and pass them to
the `markdownlint` explicitly.

---

Proof that the linter actually works - https://github.com/aws/aws-cdk-rfcs/pull/136/checks?sha=de1c5761088d78ef5a21a3b475fe8cae586d30ae

---
_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_
