### PR TITLE
RFC: 171 CloudFront Redesign

### DIFF
--- a/text/0171-cloudfront-redesign.md
+++ b/text/0171-cloudfront-redesign.md
@@ -113,25 +113,21 @@ new cloudfront.Distribution(this, 'myDist', {
 
 Note that in the above example the aliases are inferred from the certificate and do not need to be explicitly provided.
 
-## Caching Behaviors
+## Behaviors
 
-Each distribution has a default cache behavior which applies to all requests to that distribution; additional cache behaviors may be specified for a
-given URL path pattern. Cache behaviors allowing routing with multiple origins, controlling which HTTP methods to support, whether to require users to
-use HTTPS, and what query strings or cookies to forward to your origin, among other behaviors.
+Each distribution has a default behavior which applies to all requests to that distribution; additional behaviors may be specified for a
+given URL path pattern. Behaviors allow routing with multiple origins, controlling which HTTP methods to support, whether to require users to
+use HTTPS, and what query strings or cookies to forward to your origin, among others.
 
-The properties of the default cache behavior can be adjusted as part of the distribution creation. The following example shows configuring the HTTP
+The properties of the default behavior can be adjusted as part of the distribution creation. The following example shows configuring the HTTP
 methods and viewer protocol policy of the cache.
 
 ```ts
 const myWebDistribution = new cloudfront.Distribution(this, 'myDist', {
-  origin: cloudfront.Origin.fromHTTPServer({
-    domainName: 'www.example.com',
-    protocolPolicy: OriginProtocolPolicy.HTTPS_ONLY,
-  }),
-  behavior: {
+  origin: cloudfront.Origin.fromLoadBalancerV2(myLoadBalancer, {
     allowedMethods: AllowedMethods.ALL,
     viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-  }
+  }),
 });
 ```
 
@@ -196,13 +192,12 @@ The following shows a Lambda@Edge function added to the default behavior and tri
 ```ts
 const myFunc = new lambda.Function(...);
 new cloudfront.Distribution(this, 'myDist', {
-  origin: cloudfront.Origin.fromBucket(myBucket),
-  behavior: {
+  origin: cloudfront.Origin.fromBucket(myBucket, {
     edgeFunctions: [{
       functionVersion: myFunc.currentVersion,
       eventType: EventType.VIEWER_REQUEST,
-    }]
-  },
+    }],
+  }),
 });
 ```
 
@@ -424,15 +419,14 @@ new CloudFrontWebDistribution(this, 'dist', {
 
 ```ts
 const dist = new cloudfront.Distribution(this, 'MyDistribution', {
-  origin: cloudfront.Origin.fromLoadBalancerV2(lbFargateService.loadBalancer),
-  behavior: {
+  origin: cloudfront.Origin.fromLoadBalancerV2(lbFargateService.loadBalancer, {
     allowedMethods: AllowedMethods.ALL,
     forwardQueryString: true,
     edgeFunctions: [{
       function: myFunctionVersion,
       eventType: EventType.ORIGIN_RESPONSE,
-    }]
-  }
+    }],
+  }),
 });
 dist.addOrigin(cloudfront.Origin.fromBucket(sourceBucket), { pathPattern: 'static/*' });
 ```

--- a/text/0171-cloudfront-redesign.md
+++ b/text/0171-cloudfront-redesign.md
@@ -77,7 +77,7 @@ new cloudfront.Distribution(this, 'myDist', {
 
 // Creates a distribution for an HTTP server.
 new cloudfront.Distribution(this, 'myDist', {
-  origin: cloudfront.Origin.fromHTTPServer({
+  origin: cloudfront.Origin.fromHttpServer({
     domainName: 'www.example.com',
     protocolPolicy: OriginProtocolPolicy.HTTPS_ONLY,
   })
@@ -250,11 +250,10 @@ The following is an incomplete, but representative, listing of the API:
 
 ```ts
 class Distribution extends BaseDistribution {
-  static fromArn(scope: Construct, id: string, distributionArn: string): IDistribution;
-  static fromAttributes(scope: Construct, id: string, distributionArn: string): IDistribution;
+  static fromDistributionAttributes(scope: Construct, id: string, attributes: DistributionAttributes): IDistribution;
 
-  static forBucket(scope: Construct, id: string, bucket: IBucket): IDistribution;
-  static forWebsiteBucket(scope: Construct, id: string, bucket: IBucket): IDistribution;
+  static forBucket(scope: Construct, id: string, bucket: IBucket): Distribution;
+  static forWebsiteBucket(scope: Construct, id: string, bucket: IBucket): Distribution;
 
   constructor(scope: Construct, id: string, props: DistributionProps) {}
 

--- a/text/0171-cloudfront-redesign.md
+++ b/text/0171-cloudfront-redesign.md
@@ -9,170 +9,186 @@ related issue: https://github.com/aws/aws-cdk-rfcs/issues/171
 
 (Draft) Proposal to redesign the @aws-cdk/aws-cloudfront module.
 
-The current module could be enhanced to be friendlier and less error-prone.
+The current module does not adhere to the best practice naming conventions or ease-of-use patterns
+that are present in the other CDK modules. A redesign of the API will allow for friendly, easier
+access to common patterns and usages.
+
+This RFC does not attempt to lay out the entire API; rather, it focuses on a complete re-write of
+the module README with a focus on the most common use cases and how they work with the new design.
+More detailed designs and incremental API improvements will be tracked as part of GitHub Project Board
+once the RFC is approved.
+
+---
 
 # README
 
-Example usages:
+Amazon CloudFront is a web service that speeds up distribution of your static and dynamic web content, such as .html, .css, .js, and image files, to
+your users. CloudFront delivers your content through a worldwide network of data centers called edge locations. When a user requests content that
+you're serving with CloudFront, the user is routed to the edge location that provides the lowest latency, so that content is delivered with the best
+possible performance.
 
-## Use case #1 - Simple S3-bucket distribution
+## Creating a distribution
 
-Creates a distribution based on an S3 bucket, and sets up an origin access identity so the
-distribution can access the contents of the bucket (if non-public).
+CloudFront distributions deliver your content from one or more origins; an origin is the location where you store the original version of your
+content. Origins can be created from S3 buckets or a custom origin (HTTP server).
 
-**Before:**
+An S3 bucket can be added as an origin. If the bucket is configured as a website endpoint, the distribution can use S3 redirects and S3 custom error
+documents.
 
 ```ts
-new CloudFrontWebDistribution(this, 'dist', {
-  originConfigs: [{
-    s3OriginSource: {
-      s3BucketSource: myBucket,
-      originAccessIdentity: OriginAccessIdentity.fromOriginAccessIdentityName(this, 'oai', 'distOAI'),
-    },
-    behaviors: [{ isDefaultBehavior: true }],
-  }]
+// Creates a distribution for a S3 bucket.
+const myBucket = new s3.Bucket(...);
+new Distribution(this, 'myDist', {
+  origin: Origin.fromBucket(this, 'myOrigin', myBucket)
+});
+
+// Creates a distribution for a S3 bucket that has been configured for website hosting.
+const myWebsiteBucket = new s3.Bucket(...);
+new Distribution(this, 'myDist', {
+  origin: Origin.fromWebsiteBucket(this, 'myOrigin', myBucket)
 });
 ```
 
-**After:**
+Both of the S3 Origin options will automatically create an origin access identity and grant it access to the underlying bucket. This can be used in
+conjunction with a bucket that is not public to require that your users access your content using CloudFront URLs and not S3 URLs directly.
+
+Origins can also be created from other resources (e.g., load balancers, API gateways), or from any accessible HTTP server.
 
 ```ts
-new Distribution(this, 'dist', {
-  origins: [Origin.fromS3Bucket(myBucket)],
+// Creates a distribution for an application load balancer.
+const myLoadBalancer = new elbv2.ApplicationLoadBalancer(...);
+new Distribution(this, 'myDist', {
+  origin: Origin.fromLoadBalancerV2(this, 'myOrigin', myLoadBalancer)
+});
+
+// Creates a distribution for an HTTP server.
+new Distribution(this, 'myDist', {
+  origin: Origin.fromHTTPServer(this, 'myOrigin', {
+    domainName: 'www.example.com',
+    originProtocolPolicy: OriginProtocolPolicy.HTTPS_ONLY
+  })
 });
 ```
 
-## Use case #2 - S3-bucket distribution with a Lamda@Edge function
+## Domain Names and Certificates
 
-Creates a distribution based on an S3 bucket, and adds a Lambda function as a Lambda@Edge association
-to origin responses.
-
-**Before:**
+When you create a distribution, CloudFront returns a domain name for the distribution, for example: `d111111abcdef8.cloudfront.net`. If you want to
+use your own domain name, such as `www.example.com`, you can add an alternate domain name to your distribution.
 
 ```ts
-new CloudFrontWebDistribution(this, 'dist', {
-  originConfigs: [{
-    s3OriginSource: {
-      s3BucketSource: myBucket,
-      originAccessIdentity: OriginAccessIdentity.fromOriginAccessIdentityName(this, 'oai', 'distOAI'),
-    },
-    behaviors: [{
-      isDefaultBehavior: true,
-      lambdaFunctionAssociations: [{
-        lambdaFunction: myFunctionVersion,
-        eventType: LambdaEdgeEventType.ORIGIN_RESPONSE,
-      }]
-    }],
-  }]
-});
+new Distribution(this, 'myDist', {
+  origin: Origin.fromBucket(myBucket),
+  aliases: ['www.example.com']
+})
 ```
 
-**After:**
+CloudFront distributions use a default certificate (`*.cloudfront.net`) to support HTTPS by default. If you want to support HTTPS with your own domain
+name, you must associate a certificate with your distribution that contains your domain name. The certificate must be present in the AWS Certificate
+Manager (ACM) service in the US East (N. Virginia) region; the certificate may either be created by ACM, or created elsewhere and imported into ACM.
 
 ```ts
-const myBucketOrigin = Origin.fromS3Bucket(myBucket);
-new Distribution(this, 'dist', {
-  origins: [myBucketOrigin],
-  edgeFunctions: [{
-    lambdaFunctionVersion: myFunctionVersion,
-    eventType: LambdaEdgeEventType.ORIGIN_RESPONSE,
-    origin: myBucketOrigin,
-  }],
+const myCertificate = new certmgr.DnsValidatedCertificate(this, 'mySiteCert', {
+  domainName: 'www.example.com',
+  hostedZone,
 });
-```
-
-## Use Case #3 - S3 bucket distribution with certificate and custom TTL
-
-**Before:**
-
-```ts
-new CloudFrontWebDistribution(this, 'dist', {
-  originConfigs: [{
-    s3OriginSource: {
-      s3BucketSource: myBucket,
-      originAccessIdentity: OriginAccessIdentity.fromOriginAccessIdentityName(this, 'oai', 'distOAI'),
-    },
-    behaviors: [{
-      isDefaultBehavior: true,
-      defaultTtl: Duration.minutes(10),
-    }],
-  }],
-  viewerCertificate: ViewerCertificate.fromAcmCertificate(myCertificate),
-});
-```
-
-**After:**
-
-```ts
-new Distribution(this, 'dist', {
-  origins: [Origin.fromS3Bucket(myBucket)],
-  behaviors: [{defaultTtl: Duration.minutes(10)}],
+new Distribution(this, 'myDist', {
+  origin: Origin.fromBucket(myBucket),
   certificate: myCertificate,
 });
 ```
 
-## Use case #4 - Complicate multi-origin setup with multiple behaviors per origin and a Lambda@Edge function
+Note that in the above example the aliases are inferred from the certificate and do not need to be explicitly provided.
 
-Stress test. This is what the config looks like with more stuff. An S3 bucket origin with the default and
-one custom behavior, and a LoadBalancedFargateService origin that is HTTPS only.
+## Caching Behaviors
 
-**Before:**
+Each distribution has a default cache behavior which applies to all requests to that distribution; additional cache behaviors may be specified for a
+given URL path pattern. Cache behaviors allowing routing with multiple origins, controlling which HTTP methods to support, whether to require users to
+use HTTPS, and what query strings or cookies to forward to your origin, among other behaviors.
+
+The properties of the default cache behavior can be adjusted as part of the distribution creation. The following example shows configuring the HTTP
+methods and viewer protocol policy of the cache.
 
 ```ts
-new CloudFrontWebDistribution(this, 'dist', {
-  originConfigs: [{
-    s3OriginSource: {
-      s3BucketSource: websiteBucket,
-      originAccessIdentity: OriginAccessIdentity.fromOriginAccessIdentityName(this, 'oai', 'distOAI'),
-    },
-    behaviors: [
-      { isDefaultBehavior: true },
-      {
-        forwardedValues: { queryString: true },
-        pathPattern: 'images/*.jpg',
-      }
-    ],
-  },
-  {
-    customOriginSource: {
-      domainName: lbFargateService.loadBalancer.loadBalancerDnsName,
-      originProtocolPolicy: OriginProtocolPolicy.HTTPS_ONLY,
-    },
-    behaviors: [{ isDefaultBehavior: true }],
-  }],
+const myWebDistribution = new Distribution(this, 'myDist', {
+  origin: Origin.fromHTTPServer(this, 'myOrigin', {
+    domainName: 'www.example.com',
+    originProtocolPolicy: OriginProtocolPolicy.HTTPS_ONLY
+  }),
+  behavior: {
+    allowedMethods: AllowedMethods.ALL,
+    viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS
+  }
 });
 ```
 
-**After:**
+Additional cache behaviors can be specified at creation, or added to the origin(s) after the initial creation. These additional cache behaviors enable
+customization on a specific set of resources based on a URL path pattern. For example, we can add a behavior to `myWebDistribution` to override the
+default time-to-live (TTL) for all of the images.
 
 ```ts
-const myBucketOrigin = Origin.fromS3Bucket(myBucket);
-new Distribution(this, 'dist', {
-  origins: [
-    myBucketOrigin,
-    Origin.fromApplicationLoadBalancer(lbFargateService.loadBalancer),
-  ],
-  behaviors: [{
-    origin: myBucketOrigin,
-    forwardedValues: { queryString: true },
-    pathPattern: 'images/*.jpg',],
-  },
+myWebDistribution.origin.addBehavior('/images/*.jpg', {
+  viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+  defaultTtl: cdk.Duration.days(7),
+})
+```
+
+## Multiple Origins
+
+A distribution may have multiple origins in addition to the default origin; each additional origin must have (at least) one behavior to route requests
+to that origin. A common pattern might be to serve all static assets from an S3 bucket, but all dynamic content served from a web server. The
+following example shows how such a setup might be created:
+
+```ts
+const myWebsiteBucket = new s3.Bucket(...);
+const myMultiOriginDistribution = new Distribution(this, 'myDist', {
+  origin: Origin.fromWebsiteBucket(this, 'myOrigin', myBucket),
+  additionalOrigins: [Origin.fromLoadBalancerV2(this, 'myOrigin', myLoadBalancer, {
+    pathPattern: '/api/*',
+    allowedMethods: AllowedMethods.ALL,
+    forwardQueryString: true,
+  })];
 });
 ```
+
+You can specify an origin group for your CloudFront origin if, for example, you want to configure origin failover for scenarios when you need high
+availability. Use origin failover to designate a primary origin for CloudFront plus a second origin that CloudFront automatically switches to when the
+primary origin returns specific HTTP status code failure responses. An origin group can be created and specified as the primary (or additional) origin
+for the distribution.
+
+```ts
+const myOriginGroup = Origin.groupFromOrigins(
+  primaryOrigin: Origin.fromLoadBalancerV2(this, 'myOrigin', myLoadBalancer),
+  fallbackOrigin: Origin.fromBucket(this, 'myFallbackOrigin', myBucket),
+  fallbackStatusCodes: [500, 503]
+);
+new Distribution(this, 'myDist', { origin: myOriginGroup });
+```
+
+The above will create both origins and a single origin group with the load balancer origin falling back to the S3 bucket in case of 500 or 503 errors.
+
+## Lambda@Edge
+
+Lambda@Edge is an extension of AWS Lambda, a compute service that lets you execute functions that customize the content that CloudFront delivers. You
+can author Node.js or Python functions in the US East (N. Virginia) region, and then execute them in AWS locations globally that are closer to the
+viewer, without provisioning or managing servers. Lambda@Edge functions are associated with a specific behavior and
+
+**TODO:** Design the Lambda@Edge API.
+
+---
 
 # Motivation
 
 > Why are we doing this? What use cases does it support? What is the expected
 > outcome?
 
-***TODO***
+**_TODO_**
 
 # Design Summary
 
 > Summarize the approach of the feature design in a couple of sentences. Call out
 > any known patterns or best practices the design is based around.
 
-***TODO***
+**_TODO_**
 
 # Detailed Design
 
@@ -188,45 +204,6 @@ new Distribution(this, 'dist', {
 > - [Graphviz](http://graphviz.it/#/gallery/structs.gv)
 > - [PlantText](https://www.planttext.com)
 
-Proposed interfaces:
-
-```ts
-export interface DistributionProps {
-  origins?: Origin[];
-  behaviors?: Behavior[];
-  edgeFunctions?: LambdaEdgeFunction[];
-  aliases?: string[];
-  comment?: string;
-  defaultRootObject?: string;
-  enableIpV6?: boolean;
-  httpVersion?: HttpVersion;
-  priceClass?: PriceClass;
-  viewerProtocolPolicy?: ViewerProtocolPolicy;
-  webACLId?: string;
-  errorConfigurations?: ErrorConfiguration[];
-  loggingBucket?: IBucket;
-  loggingIncludeCookies?: boolean;
-  loggingPrefix?: string;
-  certificate?: certificatemanager.ICertificate;
-  sslMinimumProtocolVersion?: SslProtocolVersion;
-  sslSupportMethod?: SslSupportMethod;
-  geoLocations?: string[]; // Is there a CDK element for country codes?
-  geoRestrictionType?: GeoRestrictionType;
-}
-
-export interface BaseOriginProps {
-  domainName: string,
-
-  connectionAttempts?: int,
-  connectionTimeoutSeconds?: int,
-  id?: string,
-  originCustomHeaders?: { [key: string]: string },
-  originPath?: string,
-}
-
-...
-```
-
 # Drawbacks
 
 > Why should we _not_ do this? Please consider:
@@ -239,12 +216,6 @@ export interface BaseOriginProps {
 >
 > There are tradeoffs to choosing any path. Attempt to identify them here.
 
-***TODO***
-
-* There is a significant user base that consumes the existing interface. Despite being marked as
-'experimental', CloudFront is one of the oldest modules in the CDK and is relied on by many customers.
-Any breaking changes to the existing interface(s) will need to be carefully considered.
-
 # Rationale and Alternatives
 
 > - Why is this design the best in the space of possible designs?
@@ -252,14 +223,17 @@ Any breaking changes to the existing interface(s) will need to be carefully cons
 >   choosing them?
 > - What is the impact of not doing this?
 
-***TODO***
+## Flat vs nested origin:behaviors
+
+**TODO:** The behaviors are technically flat, allowing for arbitrary ordering of behaviors across origins. The nested approach here, while it
+  generally makes sense, makes this functionality a bit more difficult. Discuss trade-offs.
 
 # Adoption Strategy
 
 > If we implement this proposal, how will existing CDK developers adopt it? Is
 > this a breaking change? How can we assist in adoption?
 
-***TODO*** - Great question!
+**_TODO_**
 
 # Unresolved questions
 
@@ -271,9 +245,9 @@ Any breaking changes to the existing interface(s) will need to be carefully cons
 >   addressed in the future independently of the solution that comes out of this
 >   RFC?
 
-***TODO***
+**_TODO_**
 
-# Future Possibilities
+## Future Possibilities
 
 > Think about what the natural extension and evolution of your proposal would be
 > and how it would affect CDK as whole. Try to use this section as a tool to more
@@ -286,4 +260,4 @@ Any breaking changes to the existing interface(s) will need to be carefully cons
 > If you have tried and cannot think of any future possibilities, you may simply
 > state that you cannot think of anything.
 
-***TODO***
+**_TODO - Discuss "L3s" like StaticWebsiteDistribution that are all-in-one._**

--- a/text/0171-cloudfront-redesign.md
+++ b/text/0171-cloudfront-redesign.md
@@ -1,0 +1,289 @@
+---
+feature name: CloudFront redesign
+start date: 2020-06-15
+rfc pr:
+related issue: https://github.com/aws/aws-cdk-rfcs/issues/171
+---
+
+# Summary
+
+(Draft) Proposal to redesign the @aws-cdk/aws-cloudfront module.
+
+The current module could be enhanced to be friendlier and less error-prone.
+
+# README
+
+Example usages:
+
+## Use case #1 - Simple S3-bucket distribution
+
+Creates a distribution based on an S3 bucket, and sets up an origin access identity so the
+distribution can access the contents of the bucket (if non-public).
+
+**Before:**
+
+```ts
+new CloudFrontWebDistribution(this, 'dist', {
+  originConfigs: [{
+    s3OriginSource: {
+      s3BucketSource: myBucket,
+      originAccessIdentity: OriginAccessIdentity.fromOriginAccessIdentityName(this, 'oai', 'distOAI'),
+    },
+    behaviors: [{ isDefaultBehavior: true }],
+  }]
+});
+```
+
+**After:**
+
+```ts
+new Distribution(this, 'dist', {
+  origins: [Origin.fromS3Bucket(myBucket)],
+});
+```
+
+## Use case #2 - S3-bucket distribution with a Lamda@Edge function
+
+Creates a distribution based on an S3 bucket, and adds a Lambda function as a Lambda@Edge association
+to origin responses.
+
+**Before:**
+
+```ts
+new CloudFrontWebDistribution(this, 'dist', {
+  originConfigs: [{
+    s3OriginSource: {
+      s3BucketSource: myBucket,
+      originAccessIdentity: OriginAccessIdentity.fromOriginAccessIdentityName(this, 'oai', 'distOAI'),
+    },
+    behaviors: [{
+      isDefaultBehavior: true,
+      lambdaFunctionAssociations: [{
+        lambdaFunction: myFunctionVersion,
+        eventType: LambdaEdgeEventType.ORIGIN_RESPONSE,
+      }]
+    }],
+  }]
+});
+```
+
+**After:**
+
+```ts
+const myBucketOrigin = Origin.fromS3Bucket(myBucket);
+new Distribution(this, 'dist', {
+  origins: [myBucketOrigin],
+  edgeFunctions: [{
+    lambdaFunctionVersion: myFunctionVersion,
+    eventType: LambdaEdgeEventType.ORIGIN_RESPONSE,
+    origin: myBucketOrigin,
+  }],
+});
+```
+
+## Use Case #3 - S3 bucket distribution with certificate and custom TTL
+
+**Before:**
+
+```ts
+new CloudFrontWebDistribution(this, 'dist', {
+  originConfigs: [{
+    s3OriginSource: {
+      s3BucketSource: myBucket,
+      originAccessIdentity: OriginAccessIdentity.fromOriginAccessIdentityName(this, 'oai', 'distOAI'),
+    },
+    behaviors: [{
+      isDefaultBehavior: true,
+      defaultTtl: Duration.minutes(10),
+    }],
+  }],
+  viewerCertificate: ViewerCertificate.fromAcmCertificate(myCertificate),
+});
+```
+
+**After:**
+
+```ts
+new Distribution(this, 'dist', {
+  origins: [Origin.fromS3Bucket(myBucket)],
+  behaviors: [{defaultTtl: Duration.minutes(10)}],
+  certificate: myCertificate,
+});
+```
+
+## Use case #4 - Complicate multi-origin setup with multiple behaviors per origin and a Lambda@Edge function
+
+Stress test. This is what the config looks like with more stuff. An S3 bucket origin with the default and
+one custom behavior, and a LoadBalancedFargateService origin that is HTTPS only.
+
+**Before:**
+
+```ts
+new CloudFrontWebDistribution(this, 'dist', {
+  originConfigs: [{
+    s3OriginSource: {
+      s3BucketSource: websiteBucket,
+      originAccessIdentity: OriginAccessIdentity.fromOriginAccessIdentityName(this, 'oai', 'distOAI'),
+    },
+    behaviors: [
+      { isDefaultBehavior: true },
+      {
+        forwardedValues: { queryString: true },
+        pathPattern: 'images/*.jpg',
+      }
+    ],
+  },
+  {
+    customOriginSource: {
+      domainName: lbFargateService.loadBalancer.loadBalancerDnsName,
+      originProtocolPolicy: OriginProtocolPolicy.HTTPS_ONLY,
+    },
+    behaviors: [{ isDefaultBehavior: true }],
+  }],
+});
+```
+
+**After:**
+
+```ts
+const myBucketOrigin = Origin.fromS3Bucket(myBucket);
+new Distribution(this, 'dist', {
+  origins: [
+    myBucketOrigin,
+    Origin.fromApplicationLoadBalancer(lbFargateService.loadBalancer),
+  ],
+  behaviors: [{
+    origin: myBucketOrigin,
+    forwardedValues: { queryString: true },
+    pathPattern: 'images/*.jpg',],
+  },
+});
+```
+
+# Motivation
+
+> Why are we doing this? What use cases does it support? What is the expected
+> outcome?
+
+***TODO***
+
+# Design Summary
+
+> Summarize the approach of the feature design in a couple of sentences. Call out
+> any known patterns or best practices the design is based around.
+
+***TODO***
+
+# Detailed Design
+
+> This is the bulk of the RFC. Explain the design in enough detail for somebody
+> familiar with CDK to understand, and for somebody familiar with the
+> implementation to implement. This should get into specifics and corner-cases,
+> and include examples of how the feature is used. Any new terminology should be
+> defined here.
+>
+> Include any diagrams and/or visualizations that help to demonstrate the design.
+> Here are some tools that we often use:
+>
+> - [Graphviz](http://graphviz.it/#/gallery/structs.gv)
+> - [PlantText](https://www.planttext.com)
+
+Proposed interfaces:
+
+```ts
+export interface DistributionProps {
+  origins?: Origin[];
+  behaviors?: Behavior[];
+  edgeFunctions?: LambdaEdgeFunction[];
+  aliases?: string[];
+  comment?: string;
+  defaultRootObject?: string;
+  enableIpV6?: boolean;
+  httpVersion?: HttpVersion;
+  priceClass?: PriceClass;
+  viewerProtocolPolicy?: ViewerProtocolPolicy;
+  webACLId?: string;
+  errorConfigurations?: ErrorConfiguration[];
+  loggingBucket?: IBucket;
+  loggingIncludeCookies?: boolean;
+  loggingPrefix?: string;
+  certificate?: certificatemanager.ICertificate;
+  sslMinimumProtocolVersion?: SslProtocolVersion;
+  sslSupportMethod?: SslSupportMethod;
+  geoLocations?: string[]; // Is there a CDK element for country codes?
+  geoRestrictionType?: GeoRestrictionType;
+}
+
+export interface BaseOriginProps {
+  domainName: string,
+
+  connectionAttempts?: int,
+  connectionTimeoutSeconds?: int,
+  id?: string,
+  originCustomHeaders?: { [key: string]: string },
+  originPath?: string,
+}
+
+...
+```
+
+# Drawbacks
+
+> Why should we _not_ do this? Please consider:
+>
+> - implementation cost, both in term of code size and complexity
+> - whether the proposed feature can be implemented in user space
+> - the impact on teaching people how to use CDK
+> - integration of this feature with other existing and planned features
+> - cost of migrating existing CDK applications (is it a breaking change?)
+>
+> There are tradeoffs to choosing any path. Attempt to identify them here.
+
+***TODO***
+
+* There is a significant user base that consumes the existing interface. Despite being marked as
+'experimental', CloudFront is one of the oldest modules in the CDK and is relied on by many customers.
+Any breaking changes to the existing interface(s) will need to be carefully considered.
+
+# Rationale and Alternatives
+
+> - Why is this design the best in the space of possible designs?
+> - What other designs have been considered and what is the rationale for not
+>   choosing them?
+> - What is the impact of not doing this?
+
+***TODO***
+
+# Adoption Strategy
+
+> If we implement this proposal, how will existing CDK developers adopt it? Is
+> this a breaking change? How can we assist in adoption?
+
+***TODO*** - Great question!
+
+# Unresolved questions
+
+> - What parts of the design do you expect to resolve through the RFC process
+>   before this gets merged?
+> - What parts of the design do you expect to resolve through the implementation
+>   of this feature before stabilization?
+> - What related issues do you consider out of scope for this RFC that could be
+>   addressed in the future independently of the solution that comes out of this
+>   RFC?
+
+***TODO***
+
+# Future Possibilities
+
+> Think about what the natural extension and evolution of your proposal would be
+> and how it would affect CDK as whole. Try to use this section as a tool to more
+> fully consider all possible interactions with the project and ecosystem in your
+> proposal. Also consider how this fits into the roadmap for the project.
+>
+> This is a good place to "dump ideas", if they are out of scope for the RFC you
+> are writing but are otherwise related.
+>
+> If you have tried and cannot think of any future possibilities, you may simply
+> state that you cannot think of anything.
+
+***TODO***

--- a/text/0171-cloudfront-redesign.md
+++ b/text/0171-cloudfront-redesign.md
@@ -307,6 +307,12 @@ This approach was chosen as the simplest pattern to work with for the majority o
 still giving those power users control over behavior ordering, albeit implicitly. See the Rationale and Alternatives section for a discussion of
 other ways this was considered.
 
+**Implementation Note:** The relationships as-is are modeled with one-way connections; Distributions know about Origins, but Origins have no
+references to Distributions, for example. This design makes the initial creation much simpler for users, but makes having a per-Distribution
+ordered list of Behaviors impossible. To correct this, the Origin will need some form of reference to the Distribution, either at creation or
+when being associated with the Distribution. The current (inelegant) proposal is for the Origin to expose a method (`_attachDistribution`) which
+is called by the Distribution to create the relationship. Feedback on this approach (or more elegent proposals) are welcome.
+
 ## Interaction with other L2s
 
 The existing @aws-cdk/aws-cloudfront module is used in three other modules of the CDK: (1) aws-route53-patterns, (2) aws-route53-targets, and
@@ -469,6 +475,7 @@ worth it, given the breaking changes to existing consumers? The alternative is t
 and have `Distribution` directly extend `Resource`.
 2. Related to the above, should the current (CloudFrontWebDistribution) construct be marked as "stable" to indicate we won't be making future
 updates to it? Any other suggestions on how we message the "v2" on the README to highlight the new option to customers?
+3. Any better patterns for associating the Origin with the Distribution than something like the proposed `_attachDistribution`?
 
 # Future Possibilities
 

--- a/text/0171-cloudfront-redesign.md
+++ b/text/0171-cloudfront-redesign.md
@@ -46,11 +46,19 @@ new cloudfront.Distribution(this, 'myDist', {
   origin: cloudfront.Origin.fromBucket(myBucket),
 });
 
+// Equivalent to the above
+const myBucket = new s3.Bucket(...);
+cloudfront.Distribution.forBucket(this, 'myDist', myBucket);
+
 // Creates a distribution for a S3 bucket that has been configured for website hosting.
 const myWebsiteBucket = new s3.Bucket(...);
 new cloudfront.Distribution(this, 'myDist', {
   origin: cloudfront.Origin.fromWebsiteBucket(myBucket),
 });
+
+// Equivalent to the above
+const myBucket = new s3.Bucket(...);
+cloudfront.Distribution.forWebsiteBucket(this, 'myDist', myBucket);
 ```
 
 Both of the S3 Origin options will automatically create an origin access identity and grant it access to the underlying bucket. This can be used in
@@ -225,7 +233,7 @@ myImagesBehavior.addEdgeFunction({
 # Motivation
 
 The existing aws-cloudfront module doesn't adhere to standard naming convention, lacks convenience methods for more easily interacting with
-distributions, origins, and behaviors, and has been in an "experimental" state for years. This proposal aims to bring a friendlier, more ergonic
+distributions, origins, and behaviors, and has been in an "experimental" state for years. This proposal aims to bring a friendlier, more ergonomic
 interface to the module, and advance the module to a GA-ready state.
 
 # Design Summary
@@ -249,6 +257,9 @@ The following is an incomplete, but representative, listing of the API:
 class Distribution extends BaseDistribution {
   static fromArn(scope: Construct, id: string, distributionArn: string): IDistribution;
   static fromAttributes(scope: Construct, id: string, distributionArn: string): IDistribution;
+
+  static forBucket(scope: Construct, id: string, bucket: IBucket): IDistribution;
+  static forWebsiteBucket(scope: Construct, id: string, bucket: IBucket): IDistribution;
 
   constructor(scope: Construct, id: string, props: DistributionProps) {}
 

--- a/text/0171-cloudfront-redesign.md
+++ b/text/0171-cloudfront-redesign.md
@@ -460,7 +460,9 @@ on the `IBucket` interface to determine if the bucket has been configured for st
 we should treat as such. However, we could have an additional parameter to `fromBucket` trigger this
 behavior (e.g., `isConfiguredAsWebsite`?).
 2. What level of breaking changes are acceptable for the existing `IDistribution` and `CloudFrontWebDistribution` resources? Notably, the
-`IDistribution` interface should extend `IResource`, and `CloudFrontWebDistribution` changed from extending `Construct` to `Resource`.
+`IDistribution` interface should extend `IResource`, and `CloudFrontWebDistribution` changed from extending `Construct` to `Resource`. Is this
+worth it, given the breaking changes to existing consumers? The alternative is to leave both `IDistribution` and `CloudFrontWebDistribution` as-is,
+and have `Distribution` directly extend `Resource`.
 3. Related to the above, should the current (CloudFrontWebDistribution) construct be marked as "stable" to indicate we won't be making future
 updates to it? Any other suggestions on how we message the "v2" on the README to highlight the new option to customers?
 


### PR DESCRIPTION
---
title: "RFC: #0171 CloudFront Redesign"
labels: management/rfc
---

Proposal to redesign the @aws-cdk/aws-cloudfront module.

The current module does not adhere to the best practice naming conventions or ease-of-use patterns that are present in the other CDK modules. A redesign of the API will allow for friendly, easier access to common patterns and usages.

This RFC does not attempt to lay out the entire API; rather, it focuses on a complete re-write of the module README with a focus on the most common use cases and how they work with the new design. More detailed designs and incremental API improvements will be tracked as part of GitHub Project Board once the RFC is approved.

[Rendered version](/njlynch/aws-cdk-rfcs/blob/njlynch/rfc171/text/0171-cloudfront-redesign.md)


---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_
