### PR TITLE
chore: remove the messaging around conventional commits

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -26,10 +26,3 @@ pull_request_rules:
       dismiss_reviews: {}
     conditions:
       - base=master
-  - name: if fails conventional commits
-    actions:
-      comment:
-        message: Title does not follow the guidelines of [Conventional Commits](https://www.conventionalcommits.org). Please adjust title before merge.
-    conditions:
-      - -status-success=Semantic Pull Request
-      


### PR DESCRIPTION
We don't use conventional commits in our rfc repo.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_
