### PR TITLE
fix: mergify does not honour 'do-not-merge' label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,7 +14,7 @@ pull_request_rules:
       dismiss_reviews: {}
     conditions:
       - -title~=(WIP|wip)
-      - -label~=^(blocked|do-not-merge)
+      - -label~=(blocked|do-not-merge)
       - -merged
       - -closed
       - "#approved-reviews-by>=1"


### PR DESCRIPTION
mergify config had a ^ in the label match regex,
referring to 'starts with'.

Ref: https://doc.mergify.io/conditions.html

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_
