### PR TITLE
chore: re-enable "no-space-in-code" markdown rule

### DIFF
--- a/text/0192-remove-constructs-compat.md
+++ b/text/0192-remove-constructs-compat.md
@@ -121,11 +121,11 @@ migration strategies for each change.
 `@aws-cdk/core.IDependable` | `constructs.IDependable`
 `@aws-cdk/core.DependencyTrait` | `constructs.Dependable`
 `@aws-cdk.core.DependencyTrait.get(x)` | `constructs.Dependable.of(x)`
-`myConstruct.`node.dependencies`| Is now non-transitive
-`myConstruct.`addMetadata()`| Stack trace not attached by default
+`myConstruct.node.dependencies`| Is now non-transitive
+`myConstruct.addMetadata()`| Stack trace not attached by default
 `ConstructNode.prepareTree()`,`node.prepare()`,`onPrepare()`,`prepare()`| Not supported, use aspects instead
 `ConstructNode.synthesizeTree()`,`node.synthesize()`,`onSynthesize()`,`synthesize()`| Not supported
-`myConstruct.`onValidate()`,`myConstruct.`validate()`hooks | Implement`constructs.IValidation`and call`myConstruct.construct.addValidation()`instead
+`myConstruct.onValidate()`,`myConstruct.validate()`hooks | Implement`constructs.IValidation`and call`myConstruct.construct.addValidation()`instead
 `ConstructNode.validate(node)`|`myConstruct.construct.validate()`
 
 ### 00-DEPENDENCY: Declare a dependency on "constructs"

--- a/tools/linters/markdownlint.json
+++ b/tools/linters/markdownlint.json
@@ -21,6 +21,5 @@
   },
   "ol-prefix": false,
   "single-h1": false,
-  "ul-style": false,
-  "no-space-in-code": false
+  "ul-style": false
 }


### PR DESCRIPTION
The rule didn't have to be disabled. The issue was incorrect formatting of code spans.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_
