### PR TITLE
RFC 0192: Revert "node" to "construct"

### DIFF
--- a/text/0192-remove-constructs-compat.md
+++ b/text/0192-remove-constructs-compat.md
@@ -1000,7 +1000,7 @@ The following section includes sections that were rejected from inclusion in thi
 
 ### 10-CONSTRUCT-NODE
 
-Originally, we wanted to rename the `node` property to `construct` (`bucket.construct` instead of `bucket.node`). 
+Originally, we wanted to rename the `node` property to `construct` (`bucket.construct` instead of `bucket.node`).
 The motivation is described below in the original text.
 
 We eventually decided not to include this change because languages like .NET do not allow properties
@@ -1008,8 +1008,9 @@ to have the same name as the class `Construct` and `Construct` (this name is pre
 and jsii does not have any support for per-language naming.
 
 References:
- - Pull request to change all occurances of `node` to `construct` in the AWS CDK codebase: https://github.com/aws/aws-cdk/pull/9557
- - Commit which reverts this change after jsii packaging failure: https://github.com/aws/aws-cdk/commit/b6c1c8098c54160a09cae778d521fb1d3e6416f3
+
+- Pull request to change all occurances of `node` to `construct` in the AWS CDK codebase: <https://github.com/aws/aws-cdk/pull/9557>
+- Commit which reverts this change after jsii packaging failure: <https://github.com/aws/aws-cdk/commit/b6c1c8098c54160a09cae778d521fb1d3e6416f3>
 
 The original text follows:
 

--- a/text/0192-remove-constructs-compat.md
+++ b/text/0192-remove-constructs-compat.md
@@ -1007,6 +1007,10 @@ We eventually decided not to include this change because languages like .NET do 
 to have the same name as the class `Construct` and `Construct` (this name is preserved in .NET to the constructor),
 and jsii does not have any support for per-language naming.
 
+References:
+ - Pull request to change all occurances of `node` to `construct` in the AWS CDK codebase: https://github.com/aws/aws-cdk/pull/9557
+ - Commit which reverts this change after jsii packaging failure: https://github.com/aws/aws-cdk/commit/b6c1c8098c54160a09cae778d521fb1d3e6416f3
+
 The original text follows:
 
 Since we won't be able to release additional major versions of the

--- a/text/0192-remove-constructs-compat.md
+++ b/text/0192-remove-constructs-compat.md
@@ -1013,51 +1013,51 @@ The original text follows:
 > Since we won't be able to release additional major versions of the
 > "constructs" library (in order to ensure interoperability between domains is always
 > possible), we need to closely examine the API of this library.
-> 
+>
 > In particular, the API of the `Construct` class, which is the base of all
 > constructs in all CDKs, should be as small as possible in order not to "pollute"
 > domain-specific APIs introduced in various domains.
-> 
+>
 > In many cases (cdk8s, cdktf), constructs are *generated* on-demand from
 > domain-specific API specifications. In such cases, we need to ensure that the
 > API in `Construct` does not conflict with generated property names or methods.
-> 
+>
 > The current API of `Construct` in the base class (2.x, 3.x) only includes a
 > few protected `onXxx` methods (`onPrepare`, `onValidate` and
 > `onSynthesize`). Those methods will be removed in 10.x
 > ([prepare](#06-no-prepare) and [synthesize](#07-no-synthesize) are no longer
 > supported and [validate](#08-validation) will be supported through
 > `addValidation()`).
-> 
+>
 > In AWS CDK 1.x the construct API is available under `myConstruct.node`. This
 > API has been intentionally removed when we extracted "constructs" from the AWS CDK
 > in order to allow the compatibility layer in AWS CDK 1.x to use the same property name
 > and expose the shim type (jsii does not allow changing the type of a property in a subclass).
-> 
+>
 > The base library currently offers `Node.of(scope)` as an alternative - but this API is cumbersome
 > to use and not discoverable. In evidence, in CDK for Terraform, they chose to offer [`constructNode`]
 > in `TerraformElement` as a sugar for `Node.of()`.
-> 
-> 
+>
+>
 > Another downside of `Node.of()` is that it means that the `IConstruct` interface
 > is now an empty interface, which is a very weak type in TypeScript due to
 > structural typing (it's structurally identical to `any`).
-> 
+>
 > As we evaluate this use case for constructs 10.x, we would like to restore the
 > ability to access the construct API from a property of `Construct`, and use that
 > property as the single marker that represents a construct type (`IConstruct`).
-> 
-> To reduce the risk of naming conflicts (e.g. see [Terraform CDK issue](https://github.com/hashicorp/terraform-cdk/pull/230)) 
+>
+> To reduce the risk of naming conflicts (e.g. see [Terraform CDK issue](https://github.com/hashicorp/terraform-cdk/pull/230))
 > between `node` and
 > domain-specific APIs, we propose to introduce this API under the name
 > `construct` (of type `Node`).
-> 
+>
 > This has a few benefits:
-> 
+>
 > 1. It's semantically signals that "this is the construct API".
 > 2. The chance for conflicts with domain-specific names is low ("construct" is not prevalent).
 > 3. We can introduce this API while deprecating `node` in AWS CDK 1.x.
-> 
+>
 > The main downside is that it is **a breaking change** in AWS CDK 2.x. There is
 > likely quite a lot of code out there (a [few hundred](https://github.com/search?q=cdk+node.addDependency++extension%3Ats&type=Code&ref=advsearch&l=&l=)
 > results for an approximated GitHub code search).


### PR DESCRIPTION
Revert the proposal to rename `node` to `construct`. See the "Rejected Work" section for details.