### PR TITLE
Standardize on 80 character lines for easier diff viewing

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,4 +1,4 @@
-printWidth: 120
+printWidth: 80
 proseWrap: always
 semi: true
 singleQuote: true

--- a/text/0006-monolothic-packaging.md
+++ b/text/0006-monolothic-packaging.md
@@ -52,10 +52,11 @@ If we modeled all the CDK dependencies as peers (as they should be), it means,
 for example, that if an app uses the **aws-ecs** module, the app will have to
 explicitly install all the 40 transitive dependencies.
 
-The other **critical** implication of using peer dependencies is that adding a peer
-dependency to a module is in fact **A BREAKING CHANGE**. Any direct or indirect
-consumer of this module will have to explicitly install the new dependency.
-This, according to semantic versioning, requires a major version bump.
+The other **critical** implication of using peer dependencies is that adding a
+peer dependency to a module is in fact **A BREAKING CHANGE**. Any direct or
+indirect consumer of this module will have to explicitly install the new
+dependency. This, according to semantic versioning, requires a major version
+bump.
 
 ## What are we doing today?
 
@@ -80,7 +81,7 @@ This RFC proposes to release the entire AWS CDK as a single, monolithic module
 
 By releasing the CDK as a monolithic module, we can avoid the implications of
 peer dependencies across first-party modules (because there is only one module)
-*and* enable third-party libraries to safely declare the CDK as a peer
+_and_ enable third-party libraries to safely declare the CDK as a peer
 dependency (because any consumer of this library will surely have the CDK
 defined as a direct dependency).
 
@@ -170,12 +171,15 @@ into a single npm package during the build phase of the repo.
 
 The monolithic module will be organized into **submodules** that match 1:1 the
 current module system we have for the AWS CDK. These submodules will be
-implemented using typescript **namespaced exports** (see [jsii
-PR](https://github.com/aws/jsii/pull/1297)).
+implemented using typescript **namespaced exports** (see
+[jsii PR](https://github.com/aws/jsii/pull/1297)).
 
-* All `@aws-cdk/core` types will be exported without a namespace (root) ([PR #7007](https://github.com/aws/aws-cdk/pull/7007)).
-* Hyphens in the current module names will be converted to underscores (`aws-s3` => `aws_s3`).
-* The package will be organized to support "barrel imports" ([PR #6996](https://github.com/aws/aws-cdk/pull/6996))
+- All `@aws-cdk/core` types will be exported without a namespace (root)
+  ([PR #7007](https://github.com/aws/aws-cdk/pull/7007)).
+- Hyphens in the current module names will be converted to underscores (`aws-s3`
+  => `aws_s3`).
+- The package will be organized to support "barrel imports"
+  ([PR #6996](https://github.com/aws/aws-cdk/pull/6996))
 
 ## Module Names
 
@@ -183,7 +187,7 @@ PR](https://github.com/aws/jsii/pull/1297)).
 
 Package name:
 
-* **Module**: `aws-cdk-lib`
+- **Module**: `aws-cdk-lib`
 
 Usage:
 
@@ -199,15 +203,16 @@ import { aws_s3 } from 'aws-cdk-lib';
 
 Migration path:
 
-* Update `package.json` and remove all dependencies on `@aws-cdk/xyz` and add `aws-cdk-lib`.
-* Replace `"@aws-cdk"` with `"aws-cdk-lib"` in all source files.
+- Update `package.json` and remove all dependencies on `@aws-cdk/xyz` and add
+  `aws-cdk-lib`.
+- Replace `"@aws-cdk"` with `"aws-cdk-lib"` in all source files.
 
 ### Java
 
 Package name:
 
-* **Group ID**: `software.amazon.awscdk`
-* **Artifact ID**: `aws-cdk-lib`
+- **Group ID**: `software.amazon.awscdk`
+- **Artifact ID**: `aws-cdk-lib`
 
 Usage:
 
@@ -218,12 +223,13 @@ import software.amazon.awscdk.services.ec2.Vpc;
 
 Migration path:
 
-* Update `pom.xml` and replace all existing dependencies with the monolithic module.
-* No change required in source files
+- Update `pom.xml` and replace all existing dependencies with the monolithic
+  module.
+- No change required in source files
 
 Open issues:
 
-* Will core types will have to go under `software.amazon.awscdk` instead of
+- Will core types will have to go under `software.amazon.awscdk` instead of
   `software.amazon.awscdk.core`? This depends if submodule renaming will support
   specifying the per-language names for the root module.
 
@@ -231,8 +237,8 @@ Open issues:
 
 Package name:
 
-* **Namespace**: `Amazon.CDK`
-* **Package ID**: `Amazon.CDK.Lib` (sadly `Amazon.CDK` is taken by v1.0 core)
+- **Namespace**: `Amazon.CDK`
+- **Package ID**: `Amazon.CDK.Lib` (sadly `Amazon.CDK` is taken by v1.0 core)
 
 Usage:
 
@@ -245,8 +251,8 @@ using Amazon.CDK.AWS.S3;
 
 Package name:
 
-* **dist-name**: `aws-cdk-lib` or `aws-cdk`
-* **module name**: `aws_cdk` or `aws_cdk_lib` (to preserve current usage?)
+- **dist-name**: `aws-cdk-lib` or `aws-cdk`
+- **module name**: `aws_cdk` or `aws_cdk_lib` (to preserve current usage?)
 
 Usage:
 
@@ -262,13 +268,16 @@ from aws_cdk import (
 
 Migration path:
 
-* All `aws-cdk.xxx` dependencies will be removed from `requirements.txt` and replaced with `aws-cdk-lib`.
-* No change in code usage, unless we decide to rename the module to `aws_cdk_lib`.
+- All `aws-cdk.xxx` dependencies will be removed from `requirements.txt` and
+  replaced with `aws-cdk-lib`.
+- No change in code usage, unless we decide to rename the module to
+  `aws_cdk_lib`.
 
 Open issues:
 
-* Should we use `aws-cdk-lib` or `aws-cdk` as the distName?
-* Should we use `aws_cdk` as the module name to preserve compatibility or rename to `aws_cdk_lib`?
+- Should we use `aws-cdk-lib` or `aws-cdk` as the distName?
+- Should we use `aws_cdk` as the module name to preserve compatibility or rename
+  to `aws_cdk_lib`?
 
 ## Issues with Specific Modules
 
@@ -281,7 +290,7 @@ monolithic module, we will need to decide how to coordinate the protocol.
 
 The proposed solution is to continue to vend these modules as separate modules,
 but also incorporate them statically into the mono-cdk (like we do for every
-other module). This means that the mono-cdk will have a *copy* of this protocol,
+other module). This means that the mono-cdk will have a _copy_ of this protocol,
 while the CLI will take a runtime dependency on them. These protocols have a
 separate versioning model, to ensure that the outputs of the framework are
 compatible with the CLI.
@@ -343,7 +352,9 @@ To that end, we should:
   Generally, we should mostly accomodate L2s and avoid L3s to reduce the chance
   for proliferation.
 
-In the future, we can consider minifying the code to reduce it's footprint or send users to [bundlephobia](https://bundlephobia.com/result?p=monocdk-experiment).
+In the future, we can consider minifying the code to reduce it's footprint or
+send users to
+[bundlephobia](https://bundlephobia.com/result?p=monocdk-experiment).
 
 ## This is a breaking change
 
@@ -351,8 +362,8 @@ This will require major AWS CDK version bump (2.0.0) with all the implications.
 
 We can offer tools for migrating users from the old-style imports to the new
 style. The prototype ships with `@monocdk-experiment/rewrite-imports` which
-automatically rewrites `import` statements (usage: `npx
-@monocdk-experiment/rewrite-imports **/*.ts`). Still a bit flacky but quite
+automatically rewrites `import` statements (usage:
+`npx @monocdk-experiment/rewrite-imports **/*.ts`). Still a bit flacky but quite
 useful. If we allow imports like this `aws-cdk-lib/aws-s3` then this tools is
 even easier to write.
 
@@ -360,8 +371,9 @@ even easier to write.
 
 Monolithic packaging is basically the only way forward:
 
-1. **Peer dependencies are the only way to model dependencies** inside the CDK and
-   between third-party libraries and the CDK itself (see [Motivation](#motivation)).
+1. **Peer dependencies are the only way to model dependencies** inside the CDK
+   and between third-party libraries and the CDK itself (see
+   [Motivation](#motivation)).
 2. **Adding a new peer dependency is a breaking change**, which we and
    third-party library vendors simply cannot afford.
 
@@ -381,7 +393,7 @@ environments, they expect these standard libraries and runtimes to be brought in
 by their consumers. In Node.js, for example, there is a special attribute in
 `package.json` that basically defines the "peer Node.js dependency" (called
 `engines`). I would argue that if a vendor publishes a 3rd-party construct
-library, what they *really* want to say is "I am compatible with CDK >= 1.23.0".
+library, what they _really_ want to say is "I am compatible with CDK >= 1.23.0".
 Then, the decision about which actual CDK version is being used is left to the
 app level.
 
@@ -422,19 +434,21 @@ General recommendations:
 
 # Remaining Work
 
-- [ ] **Analytics**: We lose per-module analytics which means we will to move to report
-  analytics at the construct level.
-- [ ] **Reference documentation** needs to also support submodules/namespaces and
-  use the submodule's README file.
+- [ ] **Analytics**: We lose per-module analytics which means we will to move to
+      report analytics at the construct level.
+- [ ] **Reference documentation** needs to also support submodules/namespaces
+      and use the submodule's README file.
 - [ ] **Submodule renaming**: to preserve imports in some languages (i.e.
-  Java/.NET), we need to be able to explicitly specify the "coordinates" of
-  submodules in each language. For example, the S3 module is exported under the
-  `aws_s3` module in mono-cdk, but we want it's types to be defined under the
-  `software.amazon.awscdk.services.s3` Java package, so we need a way to specify
-  this mapping somehow. This might be a problem for the "core" types which are exported without a submodule in the mono-cdk, but in Java they are currently
-  under `software.amazon.awscdk.core`.
+      Java/.NET), we need to be able to explicitly specify the "coordinates" of
+      submodules in each language. For example, the S3 module is exported under
+      the `aws_s3` module in mono-cdk, but we want it's types to be defined
+      under the `software.amazon.awscdk.services.s3` Java package, so we need a
+      way to specify this mapping somehow. This might be a problem for the
+      "core" types which are exported without a submodule in the mono-cdk, but
+      in Java they are currently under `software.amazon.awscdk.core`.
 - [ ] Add module size protection during build.
-- [ ] Determine if we want to include the `-patterns` modules in monocdk or leave those as separate libraries (I lead towards separate libraries).
+- [ ] Determine if we want to include the `-patterns` modules in monocdk or
+      leave those as separate libraries (I lead towards separate libraries).
 - [ ] See open issues per language.
 
 # Future Possibilities

--- a/text/00110-cli-framework-compatibility-strategy.md
+++ b/text/00110-cli-framework-compatibility-strategy.md
@@ -6,33 +6,41 @@ related issue: https://github.com/aws/aws-cdk-rfcs/issues/110
 ---
 
 <!-- replace the blockquoted sections with your content -->
+
 # Summary
 
-This RFC addresses compatibility concerns for developing different parts of the CDK.
+This RFC addresses compatibility concerns for developing different parts of the
+CDK.
 
-It details exactly what compatibility promises we should be advertising to our customers,
-as well as proposes technical mechanisms for validating those promises are upheld.
+It details exactly what compatibility promises we should be advertising to our
+customers, as well as proposes technical mechanisms for validating those
+promises are upheld.
 
-The main concept proposed is the introduction of the *cloud-assembly-schema* package. This package will
-comprise only of the interfaces that define the communication between the framework and the CLI (or any other consumer for that matter).
+The main concept proposed is the introduction of the _cloud-assembly-schema_
+package. This package will comprise only of the interfaces that define the
+communication between the framework and the CLI (or any other consumer for that
+matter).
 
 Following are the main mechanism we will implement:
 
-- *JSII* compatibility checks on the *cloud-assembly-schema* package.
+- _JSII_ compatibility checks on the _cloud-assembly-schema_ package.
 - Decouple schema version from module version.
 - CLI regression tests.
 
-At a high level, we define the expected customer experience when upgrading either of the two CDK components:
+At a high level, we define the expected customer experience when upgrading
+either of the two CDK components:
 
-- CLI upgrades are compatible. New CLI versions should work with older framework versions, and all existing functionality is preserved.
+- CLI upgrades are compatible. New CLI versions should work with older framework
+  versions, and all existing functionality is preserved.
 
-    > By *functionality*, we mean that the CLI is able to properly interpret older frameworks and perform the
-    necessary actions to support the existing behavior.
+  > By _functionality_, we mean that the CLI is able to properly interpret older
+  > frameworks and perform the necessary actions to support the existing
+  > behavior.
 
-- Framework upgrades are comptabile **unless** the *cloud-assembly-schema* has changed, in which case, we will
-require the user to upgrade the CLI as well.
+- Framework upgrades are comptabile **unless** the _cloud-assembly-schema_ has
+  changed, in which case, we will require the user to upgrade the CLI as well.
 
-    > We will treat every change to the schema as a "breaking" one, [details](#schema-changes) below.
+      > We will treat every change to the schema as a "breaking" one, [details](#schema-changes) below.
 
 # Motivation
 
@@ -42,114 +50,144 @@ The motivation behind this RFC is three-fold:
 
 Currently, the upgrade process for our users can be a bit complicated/confusing.
 
-We generally don't require users to upgrade their CLI when they upgrade the framework.
+We generally don't require users to upgrade their CLI when they upgrade the
+framework.
 
-However, sometimes, we introduce features in the framework that rely on new CLI capabilities.
-When this happens, we bump the cx-protocol version, forcing (all) users to upgrade their CLI as well, even those who don't use the new feature.
+However, sometimes, we introduce features in the framework that rely on new CLI
+capabilities. When this happens, we bump the cx-protocol version, forcing (all)
+users to upgrade their CLI as well, even those who don't use the new feature.
 
-Things get much worse, if we forget to bump the cx-protocol version (which we do sometimes).
-In this case, the user will not receive the upgrade instruction, and will rightfully assume the new feature simply works.
-While in reality, this can either cause unexpected errors or non-working features.
+Things get much worse, if we forget to bump the cx-protocol version (which we do
+sometimes). In this case, the user will not receive the upgrade instruction, and
+will rightfully assume the new feature simply works. While in reality, this can
+either cause unexpected errors or non-working features.
 
 We want to come up with a consistent model that users can rely on.
 
 ## Simplify CX Protocol Versioning
 
-Recently, we have had a few customer impacting issues that relate to our cx-protocol.
+Recently, we have had a few customer impacting issues that relate to our
+cx-protocol.
 
 - [aws/aws-cdk: A newer version of the CDK CLI (>= 1.21.0) is necessary to interact with this app](https://github.com/aws/aws-cdk/issues/5986)
 - [aws/aws-cdk: CDK CLI can only be used with apps created by CDK >= 1.10.0](https://github.com/aws/aws-cdk/issues/4294)
 
-A major contributing factor to those issues, is that the ergonomics of introducing breaking changes (cx-protocol version bump), are not very good:
+A major contributing factor to those issues, is that the ergonomics of
+introducing breaking changes (cx-protocol version bump), are not very good:
 
-- It requires us to **remember** to bump the cx-protocol version when we introduce incompatible changes.
-- In order for newer CLI version to support older framework, we do a *synthetic* manifest upgrade. This is also something we need to **remember**.
+- It requires us to **remember** to bump the cx-protocol version when we
+  introduce incompatible changes.
+- In order for newer CLI version to support older framework, we do a _synthetic_
+  manifest upgrade. This is also something we need to **remember**.
 
-There are also some quirky implementation details, in [`versioning.ts`](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/cx-api/lib/versioning.ts):
+There are also some quirky implementation details, in
+[`versioning.ts`](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/cx-api/lib/versioning.ts):
 
 ```typescript
 const toolkitVersion = parseSemver(CLOUD_ASSEMBLY_VERSION);
 ```
 
-The CLI version takes the value of the latest cx-protocol version, and not the actual CLI version.
+The CLI version takes the value of the latest cx-protocol version, and not the
+actual CLI version.
 
 ```typescript
-
 // if framework > cli, we require a newer cli version
 if (semver.gt(frameworkVersion, toolkitVersion)) {
-  throw new Error(`A newer version of the CDK CLI (>= ${frameworkVersion}) is necessary to interact with this app`);
+  throw new Error(
+    `A newer version of the CDK CLI (>= ${frameworkVersion}) is necessary to interact with this app`,
+  );
 }
 
 // if framework < cli, we require a newer framework version
 if (semver.lt(frameworkVersion, toolkitVersion)) {
-  throw new Error(`The CDK CLI you are using requires your app to use CDK modules with version >= ${CLOUD_ASSEMBLY_VERSION}`);
+  throw new Error(
+    `The CDK CLI you are using requires your app to use CDK modules with version >= ${CLOUD_ASSEMBLY_VERSION}`,
+  );
 }
 ```
 
-This code (and comments) is contradictory to our current compatibility model, where we actually attempt to support two way compatibility.
-To facilitate this, we added the
-[`upgradeAssemblyManifest`](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/cx-api/lib/versioning.ts#L60) function.
+This code (and comments) is contradictory to our current compatibility model,
+where we actually attempt to support two way compatibility. To facilitate this,
+we added the
+[`upgradeAssemblyManifest`](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/cx-api/lib/versioning.ts#L60)
+function.
 
-Thats not to say that what we currently have can't work. But the fact that we are getting it wrong almost
-every time, implies that we should re-think the process, as well as the assumptions that lead to it.
+Thats not to say that what we currently have can't work. But the fact that we
+are getting it wrong almost every time, implies that we should re-think the
+process, as well as the assumptions that lead to it.
 
 ## Validate Compatibility
 
-We want to make sure we have sufficient testing in place that validate we don't introduce any accidental CLI compatibility breakage.
+We want to make sure we have sufficient testing in place that validate we don't
+introduce any accidental CLI compatibility breakage.
 
-**Currently, the only way for us to detect these types of problems is by noticing them in the code review process.**
+**Currently, the only way for us to detect these types of problems is by
+noticing them in the code review process.**
 
 # Design Summary
 
-Assuming we adopt the new compatibility model, all we have to do is come up with a validation mechanism for the following breakage scenarios:
+Assuming we adopt the new compatibility model, all we have to do is come up with
+a validation mechanism for the following breakage scenarios:
 
-## Breaking changes to *cloud-assembly-schema*
+## Breaking changes to _cloud-assembly-schema_
 
-Probably the most prominent scenario for causing breakage is pushing an incompatible change to the *cloud-assembly-schema* itself.
-This can, for example, be the removal of a property.
+Probably the most prominent scenario for causing breakage is pushing an
+incompatible change to the _cloud-assembly-schema_ itself. This can, for
+example, be the removal of a property.
 
-> See concrete [example](#rename-target-property-in-containerImageAssetMetadataEntry).
+> See concrete
+> [example](#rename-target-property-in-containerImageAssetMetadataEntry).
 
-The proposed solution for this case is to run API compatibility checks using `jsii-diff`.
-We would treat *cloud-assembly-schema* as a regular `jsii` module that needs to maintain compatibility to its consumers, which is the CLI.
+The proposed solution for this case is to run API compatibility checks using
+`jsii-diff`. We would treat _cloud-assembly-schema_ as a regular `jsii` module
+that needs to maintain compatibility to its consumers, which is the CLI.
 
-This will make sure that when the CLI pulls in new versions of *cloud-assembly-schema* (on upgrades), it will properly consume older cloud assemblies.
+This will make sure that when the CLI pulls in new versions of
+_cloud-assembly-schema_ (on upgrades), it will properly consume older cloud
+assemblies.
 
 ## Breaking changes in CLI
 
-Another way to break CLI upgrades, is to simply change the CLI in a breaking way. This can, for example, be a change to the docker build command.
+Another way to break CLI upgrades, is to simply change the CLI in a breaking
+way. This can, for example, be a change to the docker build command.
 
 > See concrete [example](#remove---target-from-docker-build-command).
 
-The proposed solution for this case is to run standard regression tests. That is, run old CLI integration
-tests on the latest code (Framework and CLI).
+The proposed solution for this case is to run standard regression tests. That
+is, run old CLI integration tests on the latest code (Framework and CLI).
 
-This will make sure that old CLI functionality is still working, assuming of course it was covered by our integration tests.
+This will make sure that old CLI functionality is still working, assuming of
+course it was covered by our integration tests.
 
-In addition, we will also run regression tests using new CLI code and **previous** framework version.
-This will ensure that existing CLI functionality does not rely on new framework capabilities.
+In addition, we will also run regression tests using new CLI code and
+**previous** framework version. This will ensure that existing CLI functionality
+does not rely on new framework capabilities.
 
 > See concrete [example](#change-artifact-metadata-type-value)
 
 ### Exclusions
 
-Sometimes we might need to introduce an intentional breaking change, for example for security concerns.
-This breaking change might cause one of the previous integration tests to fail, which is actually ok.
-We therefore need an escape hatch that allows us to disable specific tests during the execution of those regression tests.
+Sometimes we might need to introduce an intentional breaking change, for example
+for security concerns. This breaking change might cause one of the previous
+integration tests to fail, which is actually ok. We therefore need an escape
+hatch that allows us to disable specific tests during the execution of those
+regression tests.
 
 To that end, we will implement an exlusions mechanism:
 
 ```typescript
 [
   {
-    "test": "test-cdk-iam-diff.sh",
-    "version": "1.30.0",
-    "justification": "iam policy generation has changed in version > 1.30.0 because..."
-  }
-]
+    test: 'test-cdk-iam-diff.sh',
+    version: '1.30.0',
+    justification:
+      'iam policy generation has changed in version > 1.30.0 because...',
+  },
+];
 ```
 
-Developers will be able to add entries to this list, which will cause the suite to skip those tests.
+Developers will be able to add entries to this list, which will cause the suite
+to skip those tests.
 
 # Detailed Design
 
@@ -157,8 +195,10 @@ There are 2 mechanisms we need to implement:
 
 ## Cloud Assembly Schema Compatibility Checks
 
-We need to make sure the objects that make up what we refer to as the *cloud-assembly-schema*, do not change in a breaking way.
-We should be able to leverage `jsii` to accomplish this. For example, this is an excerpt from the `.jsii` spec of the *cx-api* module:
+We need to make sure the objects that make up what we refer to as the
+_cloud-assembly-schema_, do not change in a breaking way. We should be able to
+leverage `jsii` to accomplish this. For example, this is an excerpt from the
+`.jsii` spec of the _cx-api_ module:
 
 ```json
 "name": "ContainerImageAssetMetadataEntry",
@@ -182,19 +222,21 @@ We should be able to leverage `jsii` to accomplish this. For example, this is an
 ]
 ```
 
-This means that, if we remove the `path` property from `ContainerImageAssetMetadataEntry`, jsii should produce an error, and indeed:
+This means that, if we remove the `path` property from
+`ContainerImageAssetMetadataEntry`, jsii should produce an error, and indeed:
 
 ```console
 ❯ yarn compat
 PROP @aws-cdk/cx-api.ContainerImageAssetMetadataEntry.path: has been removed [removed:@aws-cdk/cx-api.ContainerImageAssetMetadataEntry.path]
 ```
 
-In addition, according to our new compatibility model, we need to make sure the user gets the correct error
-when the CLI version is smaller than the `Cloud-Assembly` version.
+In addition, according to our new compatibility model, we need to make sure the
+user gets the correct error when the CLI version is smaller than the
+`Cloud-Assembly` version.
 
 The plan therefore is as follows:
 
-### Step 1: Create a separate package called *cloud-assembly-schema*
+### Step 1: Create a separate package called _cloud-assembly-schema_
 
 This package will provide:
 
@@ -207,7 +249,8 @@ This package will provide:
 - ...
 - ...
 
-These are the interfaces that will be later used by the CLI. Running compatibility checks on them will ensure:
+These are the interfaces that will be later used by the CLI. Running
+compatibility checks on them will ensure:
 
 1. Rename/Remove properties is not allowed.
 2. Changing the type of a property is not allowed.
@@ -240,21 +283,26 @@ public static version(): string {}
 
 ```
 
-These methods will make sure `jsii` enforces the proper compatibility checks on those interfaces.
+These methods will make sure `jsii` enforces the proper compatibility checks on
+those interfaces.
 
-> Note: The existence of the `load` method will also enforce output posture compatibility checks.
-> Essentially this means that we will not be able to make a required field optional.
-> This might sound non intuitive, but actually makes sense. These interfaces are exposed to our customers,
-> who might programtically access their properties. We wouldn't want user code to break because a property now might be `undefined`.
+> Note: The existence of the `load` method will also enforce output posture
+> compatibility checks. Essentially this means that we will not be able to make
+> a required field optional. This might sound non intuitive, but actually makes
+> sense. These interfaces are exposed to our customers, who might programtically
+> access their properties. We wouldn't want user code to break because a
+> property now might be `undefined`.
 
-This new package also has to be **stable**. This is ok, it actually makes perfect sense for it to be stable as it
-represents the structural contract the `cloud-assembly-schema` needs to adhere to.
+This new package also has to be **stable**. This is ok, it actually makes
+perfect sense for it to be stable as it represents the structural contract the
+`cloud-assembly-schema` needs to adhere to.
 
 #### (3) Json Schema
 
-We will create a standard [*json-schema*](https://json-schema.org/), that will be generated from the `typescript` interfaces.
-The schema file will be versioned separately from the module version, and consumers will be able to use it
-to validate cloud assemblies that they are interacting with.
+We will create a standard [_json-schema_](https://json-schema.org/), that will
+be generated from the `typescript` interfaces. The schema file will be versioned
+separately from the module version, and consumers will be able to use it to
+validate cloud assemblies that they are interacting with.
 
 For example:
 
@@ -280,95 +328,113 @@ For example:
 
 ### Step 2: Validate Schema Version
 
-The highest schema version that the CLI can accept, is the schema version that it was shipped with.
-This version is exposed via the static `version` method in the *cloud-assembly-package*.
+The highest schema version that the CLI can accept, is the schema version that
+it was shipped with. This version is exposed via the static `version` method in
+the _cloud-assembly-package_.
 
 If the CLI encounteres assemblies with a higher version, it should reject them.
 
-To enforce this, we will add a validation in the CLI, immediately after we de-serialize the `Cloud-Assembly`:
+To enforce this, we will add a validation in the CLI, immediately after we
+de-serialize the `Cloud-Assembly`:
 
-> Note that the de-serialization will always work because we cannot push breaking changes to the schema.
+> Note that the de-serialization will always work because we cannot push
+> breaking changes to the schema.
 
 in `exec.ts`
 
 ```typescript
 var assembly;
 
-if (await fs.pathExists(app) && (await fs.stat(app)).isDirectory()) {
-    debug('--app points to a cloud assembly, so we by pass synth');
-    assembly = new cxapi.CloudAssembly(app);
+if ((await fs.pathExists(app)) && (await fs.stat(app)).isDirectory()) {
+  debug('--app points to a cloud assembly, so we by pass synth');
+  assembly = new cxapi.CloudAssembly(app);
 } else {
-    debug('--app points to an executable, let the framework do its thing');
-    await exec();
-    assembly = new cxapi.CloudAssembly(outdir);
+  debug('--app points to an executable, let the framework do its thing');
+  await exec();
+  assembly = new cxapi.CloudAssembly(outdir);
 }
 
 // reject assemblies created with a higher version than what we expect.
 if (Schema.version() < assembly.version) {
-    throw new Error(`Cloud assembly schema version mismatch...`);
+  throw new Error(`Cloud assembly schema version mismatch...`);
 }
 ```
 
-This implies that the `version` in `manifest.json` will no longer be the value of `CLOUD_ASSEMBLY_VERSION`,
-it will simply be the version of schema that was used to create it.
+This implies that the `version` in `manifest.json` will no longer be the value
+of `CLOUD_ASSEMBLY_VERSION`, it will simply be the version of schema that was
+used to create it.
 
 To actually validate this behavior, we add a unit test for the `exec.ts` file.
 
 ### Step 3: Remove [`versioning.ts`](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/cx-api/lib/versioning.ts)
 
-Given all the above steps, we don't need the functionality provided
-by [`versioning.ts`](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/cx-api/lib/versioning.ts).
+Given all the above steps, we don't need the functionality provided by
+[`versioning.ts`](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/cx-api/lib/versioning.ts).
 Lets dive deep into why is that exactly.
 
 #### Schema Evolution
 
-The schema in `manifest.json` might be incomplete/different with regards to the expectation of new CLI versions.
+The schema in `manifest.json` might be incomplete/different with regards to the
+expectation of new CLI versions.
 
-For example, the CLI might assume that a `newProperty` will always exist in the manifest,
-because it was added as a required property in new schema versions.
-In order for the new CLI version to not fail on older schemas, where `newProperty` doesn't exist,
-we perform whats called a *schema evolution*.
+For example, the CLI might assume that a `newProperty` will always exist in the
+manifest, because it was added as a required property in new schema versions. In
+order for the new CLI version to not fail on older schemas, where `newProperty`
+doesn't exist, we perform whats called a _schema evolution_.
 
-That is, we read the **old** schema, and add the necessary properties (with some default values) in order for
-it to look exactly like the **new** schema would. This enables the CLI to essentially not be aware of any schema version expect for the last one.
+That is, we read the **old** schema, and add the necessary properties (with some
+default values) in order for it to look exactly like the **new** schema would.
+This enables the CLI to essentially not be aware of any schema version expect
+for the last one.
 
-This is done in the [`upgradeAssemblyManifest`](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/cx-api/lib/versioning.ts#L60) function.
+This is done in the
+[`upgradeAssemblyManifest`](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/cx-api/lib/versioning.ts#L60)
+function.
 
-We stipulate that this is no longer needed. The compatibility checks will make sure we don't add a required property,
-or do any change that enables the CLI to rely on the structure of the new schemas. This will actually also be enforced by
-the compiler itself. For example, if we add a property, it has to be optional (because of the compatibility checks),
-and if its optional, the CLI has to, at compile time, treat the `undefined` scenario, hence, supporting earlier schemas that didn't have this property.
+We stipulate that this is no longer needed. The compatibility checks will make
+sure we don't add a required property, or do any change that enables the CLI to
+rely on the structure of the new schemas. This will actually also be enforced by
+the compiler itself. For example, if we add a property, it has to be optional
+(because of the compatibility checks), and if its optional, the CLI has to, at
+compile time, treat the `undefined` scenario, hence, supporting earlier schemas
+that didn't have this property.
 
-Removing this mechanism will mean that instead of, theoretically, having only place consider older versions of the schema,
-we will now have multiple places in the code that should be aware of it. But thats ok, because its enforced by the compiler,
-and it also provides better context and granularity for doing that so called evolution.
+Removing this mechanism will mean that instead of, theoretically, having only
+place consider older versions of the schema, we will now have multiple places in
+the code that should be aware of it. But thats ok, because its enforced by the
+compiler, and it also provides better context and granularity for doing that so
+called evolution.
 
-Also, in reality, we don't actually do any evolution. All we do is synthetically upgrade the schema version,
-without adding or modifying any properties.
+Also, in reality, we don't actually do any evolution. All we do is synthetically
+upgrade the schema version, without adding or modifying any properties.
 
 This brings us to the next item.
 
 #### Compatibility Validation
 
-This is done in the [`verifyManifestVersion`](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/cx-api/lib/versioning.ts#L39) function,
-and contains two validations:
+This is done in the
+[`verifyManifestVersion`](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/cx-api/lib/versioning.ts#L39)
+function, and contains two validations:
 
 1. **Framework cannot be bigger than CLI.**
 
-   We have already [described](#step-3-validate-cli--framework) how to handle this validation.
+   We have already [described](#step-3-validate-cli--framework) how to handle
+   this validation.
 
 2. **CLI cannot be bigger than Framework.**
 
-   This validation is actually misleading, since we do support CLI > Framework. The way its currently implemented is by doing
-   the aforementioned evolution. But, if the evolution is not necessary anymore, than this validation is not necessary anymore.
-   Which makes sense, since we do support this scenario.
+   This validation is actually misleading, since we do support CLI > Framework.
+   The way its currently implemented is by doing the aforementioned evolution.
+   But, if the evolution is not necessary anymore, than this validation is not
+   necessary anymore. Which makes sense, since we do support this scenario.
 
 ## CLI Regression Tests
 
 The second major mechanism we need to implement is CLI regression tests.
 
-As already mentioned, *cloud-assembly-schema* API breakage is not the only thing that can go wrong.
-This is to ensure that we don't introduce breaking changes to the CLI itself. The plan here is fairly straight forward:
+As already mentioned, _cloud-assembly-schema_ API breakage is not the only thing
+that can go wrong. This is to ensure that we don't introduce breaking changes to
+the CLI itself. The plan here is fairly straight forward:
 
 ```console
 git checkout v${LATEST_PUBLISHED_VERSION}
@@ -384,76 +450,96 @@ yarn integ-cli
 
 ## Schema Changes
 
-Imagine that we add an **optional** property to one of the interfaces, and change the CLI to use this new property (in a backwards compatible way of course).
-One might argue that existing CLI versions are still able to deploy those new assemblies, they will simply ignore the new property.
+Imagine that we add an **optional** property to one of the interfaces, and
+change the CLI to use this new property (in a backwards compatible way of
+course). One might argue that existing CLI versions are still able to deploy
+those new assemblies, they will simply ignore the new property.
 
-However, how will they know the nature of this new property? Deploying such a cloud assembly implies ignoring some instructions
-that might be critical to the assembly as a whole.
+However, how will they know the nature of this new property? Deploying such a
+cloud assembly implies ignoring some instructions that might be critical to the
+assembly as a whole.
 
-For this reason, we treat **any** change to the schema as a "breaking" change, not just changes that break the format validation.
-This breaking change will be communicated as a `major` version bump of the schema.
+For this reason, we treat **any** change to the schema as a "breaking" change,
+not just changes that break the format validation. This breaking change will be
+communicated as a `major` version bump of the schema.
 
 # Adoption Strategy
 
-Adoption of this strategy should be rather seamless for developers. The changes a developer would need to incorporate,
-will be guided by failing tests. Hopefully, the process will not require any memorization (or even documentation).
+Adoption of this strategy should be rather seamless for developers. The changes
+a developer would need to incorporate, will be guided by failing tests.
+Hopefully, the process will not require any memorization (or even
+documentation).
 
-Having said that, this RFC can be a good reference documentation that provides rational for every step in the process.
+Having said that, this RFC can be a good reference documentation that provides
+rational for every step in the process.
 
 # Future Possibilities
 
-## Cleanup *cx-api*
+## Cleanup _cx-api_
 
-Separating *cloud-assembly-schema* stuff from *cx-api*, opens the door for doing a thorough cleanup. I think *cx-api* was initially
-regarded as the place for *cloud-assembly-schema*, though it currently contains a lot of other stuff. We should do an overview of the
-code inside *cx-api*, and move it to the appropriate place.
+Separating _cloud-assembly-schema_ stuff from _cx-api_, opens the door for doing
+a thorough cleanup. I think _cx-api_ was initially regarded as the place for
+_cloud-assembly-schema_, though it currently contains a lot of other stuff. We
+should do an overview of the code inside _cx-api_, and move it to the
+appropriate place.
 
 ### CLI API Compatibility Checks
 
-If we think about it, in the same way that the framework exposes a protocol to the CLI, the CLI in turn exposes a protocol to the end user.
-For example, all the CLI command line options, are part of this protocol. The compatibility requirements on those options
-are essentially the same as those of properties in the *cloud-assembly-schema* object model.
+If we think about it, in the same way that the framework exposes a protocol to
+the CLI, the CLI in turn exposes a protocol to the end user. For example, all
+the CLI command line options, are part of this protocol. The compatibility
+requirements on those options are essentially the same as those of properties in
+the _cloud-assembly-schema_ object model.
 
-We could model those options in an object model, and run compatibility checks on that model. This will ensure we don't accidentally
-remove an option or make one required, for example.
+We could model those options in an object model, and run compatibility checks on
+that model. This will ensure we don't accidentally remove an option or make one
+required, for example.
 
-### Integration tests for *cx-api*
+### Integration tests for _cx-api_
 
 Like already [mentioned](#change-artifact-metadata-type-value), the fact that
-the cx protocol itself will remain API comptabile, doesn't necessarily mean
-that it can't break new CLI versions.
+the cx protocol itself will remain API comptabile, doesn't necessarily mean that
+it can't break new CLI versions.
 
-Another compatibility layer we can add, is run snapshot testing, similair to what we do with our construct libraries.
-There, we make sure the CloudFormation template remains the same, here,
-we make sure the `manifest.json` remains the same (values wise).
+Another compatibility layer we can add, is run snapshot testing, similair to
+what we do with our construct libraries. There, we make sure the CloudFormation
+template remains the same, here, we make sure the `manifest.json` remains the
+same (values wise).
 
-These types of tests however are somewhat volatile because we can accidentally push a snapshot change that is in fact breaking.
-API compatibility checks on the other do not have this vulunerability
-because we don't have control on the compatibility rules themselves.
+These types of tests however are somewhat volatile because we can accidentally
+push a snapshot change that is in fact breaking. API compatibility checks on the
+other do not have this vulunerability because we don't have control on the
+compatibility rules themselves.
 
 # Appendix
 
 ## Rename target property in `ContainerImageAssetMetadataEntry`
 
-This is a concrete example on how things can break when we introduce changes to the *cx-api*.
+This is a concrete example on how things can break when we introduce changes to
+the _cx-api_.
 
-1. Rename `target` in [`ContainerImageAssetMetadataEntry`](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/cx-api/lib/assets.ts#L74) to `buildTarget`.
+1. Rename `target` in
+   [`ContainerImageAssetMetadataEntry`](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/cx-api/lib/assets.ts#L74)
+   to `buildTarget`.
 2. Perform necessary changes in CLI and fix all relevant tests.
 
 Our current CLI backwards compatibility tests will not detect this because:
 
-- We don't run CLI integration tests on old assemblies that use `ContainerImageAssetMetadataEntry`.
+- We don't run CLI integration tests on old assemblies that use
+  `ContainerImageAssetMetadataEntry`.
 - We only run `cdk synth`, but this problem would be reviled in `cdk deploy`.
 
-However, what will happen is the new CLI will ignore the `target` property that might exist in old cloud-assemblies,
-resulting in the breakage of this feature.
+However, what will happen is the new CLI will ignore the `target` property that
+might exist in old cloud-assemblies, resulting in the breakage of this feature.
 
-Note that we didn't mention wether or not the developer remembered to bump the version of *cloud-assembly-schema*.
-Thats because it doesn't matter, CLI upgrades should work regardless.
+Note that we didn't mention wether or not the developer remembered to bump the
+version of _cloud-assembly-schema_. Thats because it doesn't matter, CLI
+upgrades should work regardless.
 
 ## Remove `--target` from docker build command
 
-1. For some reason, we decide to stop passing `--target` to the docker build command.
+1. For some reason, we decide to stop passing `--target` to the docker build
+   command.
 2. Perform necessary changes and fix all relevant tests.
 
 This type of change is forbidden, because it removes an existing CLI capability.
@@ -463,21 +549,27 @@ However, nothing will catch this breaking change because:
 - The tests were explicitly changed to the support the removal of this feature.
 - API compatibility is still intact, the CLI is simply not using it as expected.
 
-Running regression tests, i.e, running previous integration tests, will catch this because we had a test that checks the `--target` feature (hopefully).
+Running regression tests, i.e, running previous integration tests, will catch
+this because we had a test that checks the `--target` feature (hopefully).
 
 ## Change artifact metadata type value
 
 1. For some reason, we decide to rename the
-[`aws:cdk:asset`](https://github.com/aws/aws-cdk/blob/b52b43ddfea0398b3f6e05002bf5b97bc831d1a7/packages/%40aws-cdk/cx-api/lib/assets.ts#L1) marker.
+   [`aws:cdk:asset`](https://github.com/aws/aws-cdk/blob/b52b43ddfea0398b3f6e05002bf5b97bc831d1a7/packages/%40aws-cdk/cx-api/lib/assets.ts#L1)
+   marker.
 2. Perform necessary changes and fix all relevant tests.
 
-This type of change is forbidden, because it means new CLI versions will not work with cloud assemblies that are created by older framework versions.
+This type of change is forbidden, because it means new CLI versions will not
+work with cloud assemblies that are created by older framework versions.
 
 However, nothing will catch this breaking change because:
 
 - The tests were explicitly changed to the support the removal of this feature.
-- API compatibility is still intact, nothing in the structure of `manifest.json` changed, just the values.
-- Even the regression tests we talked about wont catch this because they always use new framework versions that create
-cloud assemblies that are compatible with new cli versions.
+- API compatibility is still intact, nothing in the structure of `manifest.json`
+  changed, just the values.
+- Even the regression tests we talked about wont catch this because they always
+  use new framework versions that create cloud assemblies that are compatible
+  with new cli versions.
 
-In order to reject this type of change, we need to run the regression suite, but using older framework versions.
+In order to reject this type of change, we need to run the regression suite, but
+using older framework versions.

--- a/text/0049-continuous-delivery.md
+++ b/text/0049-continuous-delivery.md
@@ -1,17 +1,23 @@
 # Continuous Delivery for CDK Apps
 
-This is a specification for the continuous delivery support feature for CDK apps. It describes the requirements, proposed APIs and developer workflow.
+This is a specification for the continuous delivery support feature for CDK
+apps. It describes the requirements, proposed APIs and developer workflow.
 
 **_Goal_: Full CI/CD for CDK apps at any complexity.**
 
-The desired developer experience is that teams will be able to "git push" a change into their CDK app repo and have this change automatically picked
-up, built, tested and deployed according to a deployment flow they define.
+The desired developer experience is that teams will be able to "git push" a
+change into their CDK app repo and have this change automatically picked up,
+built, tested and deployed according to a deployment flow they define.
 
-Any changes in resources, assets *or stacks* in their apps will automatically be added. To that end, the deployment pipeline itself will also be
-continuously delivered and updated throughout the same workflow. No manual deployments to production (incl. the pipeline) will be required.
+Any changes in resources, assets _or stacks_ in their apps will automatically be
+added. To that end, the deployment pipeline itself will also be continuously
+delivered and updated throughout the same workflow. No manual deployments to
+production (incl. the pipeline) will be required.
 
-The only caveat is that **new environments** (account/region) will need to be bootstrapped in advance in order to establish trust with the central
-pipeline environment and set-up resources needed for deployment such as the assets S3 bucket.
+The only caveat is that **new environments** (account/region) will need to be
+bootstrapped in advance in order to establish trust with the central pipeline
+environment and set-up resources needed for deployment such as the assets S3
+bucket.
 
 - [Requirements](#requirements)
 - [Approach](#approach)
@@ -35,47 +41,68 @@ pipeline environment and set-up resources needed for deployment such as the asse
 
 ## Requirements
 
-This list describes only the minimal set of requirements from this feature. After we release these building blocks, we will look into vending
-higher-level "one liner" APIs that will make it very easy to get started.
+This list describes only the minimal set of requirements from this feature.
+After we release these building blocks, we will look into vending higher-level
+"one liner" APIs that will make it very easy to get started.
 
-1. **Deployment system**: the design should focus on building blocks that can be easily integrated into various deployment systems. This spec
-   describes the integration with the CDK CLI and AWS CodePipelines, but it should be applicable to any deployment system.
-1. **Assets**: Support apps that include all supported assets (S3 files, ECR images)
-1. **Multi-environment**: Support apps that have stacks that target multiple environments (accounts/regions)
-1. **Orchestration**: Allow developers to express complex deployment orchestration based on the capabilities of CodePipeline
-1. **User-defined build+synth runtime**: the runtime environment in which the code is built and the CDK app is synthesized should be fully
-   customizable by the user
-1. **Restricted deployment runtime**: for security reasons, the runtime environment in which deployment is executed will not allow running user code
+1. **Deployment system**: the design should focus on building blocks that can be
+   easily integrated into various deployment systems. This spec describes the
+   integration with the CDK CLI and AWS CodePipelines, but it should be
+   applicable to any deployment system.
+1. **Assets**: Support apps that include all supported assets (S3 files, ECR
+   images)
+1. **Multi-environment**: Support apps that have stacks that target multiple
+   environments (accounts/regions)
+1. **Orchestration**: Allow developers to express complex deployment
+   orchestration based on the capabilities of CodePipeline
+1. **User-defined build+synth runtime**: the runtime environment in which the
+   code is built and the CDK app is synthesized should be fully customizable by
+   the user
+1. **Restricted deployment runtime**: for security reasons, the runtime
+   environment in which deployment is executed will not allow running user code
    or user-defined image
-1. **Bootstrapping**: it should be possible to leverage existing AWS account stamping tools like AWS CloudFormation StackSets and AWS Control Tower in
+1. **Bootstrapping**: it should be possible to leverage existing AWS account
+   stamping tools like AWS CloudFormation StackSets and AWS Control Tower in
    order to manage bootstrapping at scale.
-1. **Custom replication**: In order to support isolated and air-gapped regions, as well as deployment across partitions, the solution should support
+1. **Custom replication**: In order to support isolated and air-gapped regions,
+   as well as deployment across partitions, the solution should support
    customizing how and where assets are published and replicated to.
 
 _Considerations:_
 
-* Prefer to use standard CloudFormation pipeline actions to reduce costs, leverage UI and allow restriction of the deployment role to the
-  CloudFormation service principal.
-* Execution of `cdk synth` or `docker build` should not be done in a context with administrative privileges to avoid injection of malicious code into
-  a privileged environment.
+- Prefer to use standard CloudFormation pipeline actions to reduce costs,
+  leverage UI and allow restriction of the deployment role to the CloudFormation
+  service principal.
+- Execution of `cdk synth` or `docker build` should not be done in a context
+  with administrative privileges to avoid injection of malicious code into a
+  privileged environment.
 
 _Non-requirements/assumptions:_
 
-* We assume that **cdk.context.json** is committed into the repo. Any context-fetching will be done manually by users and committed to the repository.
-* There’s a one-to-one mapping between an app and a pipeline. We are not optimizing the experience for multiple apps per pipeline (although
-  technically it should be possible to do it, but it’s not a use case we are focused on).
-* Dependency management, repository and project structure are out of scope: we don’t want to be opinionated about how users should structure their
-  projects. They should be able to use the tools they are familiar with and are available to their teams to structure and modularize their
-  applications.
-* Assets will not be supported in environment-agnostic stacks. [#4131](https://github.com/aws/aws-cdk/pull/4131) proposes that `cdk deploy` will
-  default `env` to the current account/region, which means that the CLI use case will no longer treat stacks as environment-agnostic.
+- We assume that **cdk.context.json** is committed into the repo. Any
+  context-fetching will be done manually by users and committed to the
+  repository.
+- There’s a one-to-one mapping between an app and a pipeline. We are not
+  optimizing the experience for multiple apps per pipeline (although technically
+  it should be possible to do it, but it’s not a use case we are focused on).
+- Dependency management, repository and project structure are out of scope: we
+  don’t want to be opinionated about how users should structure their projects.
+  They should be able to use the tools they are familiar with and are available
+  to their teams to structure and modularize their applications.
+- Assets will not be supported in environment-agnostic stacks.
+  [#4131](https://github.com/aws/aws-cdk/pull/4131) proposes that `cdk deploy`
+  will default `env` to the current account/region, which means that the CLI use
+  case will no longer treat stacks as environment-agnostic.
 
 ## Approach
 
-The general approach is that deployment of a CDK app is governed by a central system (e.g. an AWS CodePipeline, a Jenkins system or any other
-deployment tool). This central deployment system runs within credentials from a central deployment account, which then assumes roles within all other
-accounts that can then deploy resources to them. This deployment account is referred to as the **tools account** in the [CodePipeline Cross Account
-Reference Architecture](https://github.com/awslabs/aws-refarch-cross-account-pipeline).
+The general approach is that deployment of a CDK app is governed by a central
+system (e.g. an AWS CodePipeline, a Jenkins system or any other deployment
+tool). This central deployment system runs within credentials from a central
+deployment account, which then assumes roles within all other accounts that can
+then deploy resources to them. This deployment account is referred to as the
+**tools account** in the
+[CodePipeline Cross Account Reference Architecture](https://github.com/awslabs/aws-refarch-cross-account-pipeline).
 
 At a high-level, we will model the deployment process of a CDK app as follows:
 
@@ -83,76 +110,101 @@ At a high-level, we will model the deployment process of a CDK app as follows:
 bootstrap => source => build => synthesis => mutate => publish => deploy
 ```
 
-1. **bootstrap**: provision resources required to deploy CDK apps into all environments in advance (such as an S3 bucket, ECR repository and various
-   IAM roles that trust the central deployment account).
-2. **source**: the code is pulled from a source repository (e.g. CodeCommit, GitHub or S3), like any other app.
-3. **build + synthesis**: compiles the CDK app code into an executable program (user-defined) and invokes the compiled executable through `cdk synth`
-   to produce a [cloud assembly](https://github.com/aws/aws-cdk/blob/master/design/cloud-assembly.md) from the app. The cloud assembly includes a
-   CloudFormation template for each stack and asset sources (docker images, s3 files, etc) that must be packaged and published to the asset store in
-   each environment that consumes them.
-4. **mutate**: update stack(s) required by the pipeline. This includes pipeline resources and other auxiliary resources such as regional replication
-   buckets. These stacks are limited to 50KiB and are not allowed to use assets, so they can be deployed without bootstrapping resources.
-5. **publish**: package and publish all assets to asset stores (S3 bucket, ECR repository) so they can be consumed.
-6. **deploy**: stage(s), stacks are deployed to the various environments through some orchestration process (e.g. deploy first to this region, run
-   these canaries, wait for errors, continue to the next stage, etc).
+1. **bootstrap**: provision resources required to deploy CDK apps into all
+   environments in advance (such as an S3 bucket, ECR repository and various IAM
+   roles that trust the central deployment account).
+2. **source**: the code is pulled from a source repository (e.g. CodeCommit,
+   GitHub or S3), like any other app.
+3. **build + synthesis**: compiles the CDK app code into an executable program
+   (user-defined) and invokes the compiled executable through `cdk synth` to
+   produce a
+   [cloud assembly](https://github.com/aws/aws-cdk/blob/master/design/cloud-assembly.md)
+   from the app. The cloud assembly includes a CloudFormation template for each
+   stack and asset sources (docker images, s3 files, etc) that must be packaged
+   and published to the asset store in each environment that consumes them.
+4. **mutate**: update stack(s) required by the pipeline. This includes pipeline
+   resources and other auxiliary resources such as regional replication buckets.
+   These stacks are limited to 50KiB and are not allowed to use assets, so they
+   can be deployed without bootstrapping resources.
+5. **publish**: package and publish all assets to asset stores (S3 bucket, ECR
+   repository) so they can be consumed.
+6. **deploy**: stage(s), stacks are deployed to the various environments through
+   some orchestration process (e.g. deploy first to this region, run these
+   canaries, wait for errors, continue to the next stage, etc).
 
-NOTE: The deployment phase can include any number of stack deployment actions. Each deployment action is responsible deploy a single stack, along with
-any assets it references.
+NOTE: The deployment phase can include any number of stack deployment actions.
+Each deployment action is responsible deploy a single stack, along with any
+assets it references.
 
 This following sections describes the design of each component in the toolchain.
 
 ## Build + Synthesis
 
-In this stage we compile the CDK app to an executable program through a user-defined build system and synthesize a cloud assembly from it.
+In this stage we compile the CDK app to an executable program through a
+user-defined build system and synthesize a cloud assembly from it.
 
-We assume a single source repository which masters the CDK app itself. This repo can be structured in any way users wish, and may include multiple
-modules or just a single one. If users choose to organize their project into modules and master different modules in other repositories, eventually
-the build artifacts from these builds should be available when the app is synthesized.
+We assume a single source repository which masters the CDK app itself. This repo
+can be structured in any way users wish, and may include multiple modules or
+just a single one. If users choose to organize their project into modules and
+master different modules in other repositories, eventually the build artifacts
+from these builds should be available when the app is synthesized.
 
-The only requirement from the build step is the it will have an output artifact that is a cloud-assembly directory which is obtained through `cdk
-synth` (defaults to `./cdk.out`). Other than that, users can fully control their build environment.
+The only requirement from the build step is the it will have an output artifact
+that is a cloud-assembly directory which is obtained through `cdk synth`
+(defaults to `./cdk.out`). Other than that, users can fully control their build
+environment.
 
-The implication is that users will have to manually configure their build step to invoke `cdk synth` when the app is ready (e.g. code has been
-compiled).
+The implication is that users will have to manually configure their build step
+to invoke `cdk synth` when the app is ready (e.g. code has been compiled).
 
-The CDK synthesizes a CloudFormation template for each stack defined in the CDK app. When stacks are defined, users can specify the target environment
-(account and region) into which the stack should be deployed:
+The CDK synthesizes a CloudFormation template for each stack defined in the CDK
+app. When stacks are defined, users can specify the target environment (account
+and region) into which the stack should be deployed:
 
 ```ts
-new Stack(this, 'my-stack', { env: { account: '123456789012', region: 'us-east-1' } });
+new Stack(this, 'my-stack', {
+  env: { account: '123456789012', region: 'us-east-1' },
+});
 ```
 
 ### Multiple Environments
 
-In order to support deploying stacks from a centralized (pipeline/development) environment to other environments, the bootstrap stack includes a set
-of named IAM roles which trust the central account for publishing and deployment.
+In order to support deploying stacks from a centralized (pipeline/development)
+environment to other environments, the bootstrap stack includes a set of named
+IAM roles which trust the central account for publishing and deployment.
 
-In order to encourage separation of concerns and allow customizability, we will add role information to the assembly manifest.
+In order to encourage separation of concerns and allow customizability, we will
+add role information to the assembly manifest.
 
 For each stack, we will encode additional two IAM roles:
 
-1. Administrator CloudFormation IAM role which can only be assumed by the CloudFormation service principal (also known as the "action role" in
+1. Administrator CloudFormation IAM role which can only be assumed by the
+   CloudFormation service principal (also known as the "action role" in
    CodePipeline terminology)
-2. Deployment IAM role which can be assumed by any principal from the central account and has permissions to "pass role" on the administrator role
-   (also known as the "CFN role" in CodePipeline terminology).
+2. Deployment IAM role which can be assumed by any principal from the central
+   account and has permissions to "pass role" on the administrator role (also
+   known as the "CFN role" in CodePipeline terminology).
 
-> The publisher role which is also provisioned during bootstrapping is encoded in the `assets.json` file *per-asset* to allow for maximum
-> customizability.
+> The publisher role which is also provisioned during bootstrapping is encoded
+> in the `assets.json` file _per-asset_ to allow for maximum customizability.
 
 This is the recommended setup for cross-account CloudFormation deployments.
 
 ### Assets
 
-Users can reference "assets" within their CDK app. Assets represent artifacts produced from local files and used by the app at runtime. The CDK
-currently supports file assets served from Amazon S3 and docker image assets served from Amazon ECR.
+Users can reference "assets" within their CDK app. Assets represent artifacts
+produced from local files and used by the app at runtime. The CDK currently
+supports file assets served from Amazon S3 and docker image assets served from
+Amazon ECR.
 
-For example, this is a definition of an AWS Lambda function that uses the code from the `my-handler` directory:
+For example, this is a definition of an AWS Lambda function that uses the code
+from the `my-handler` directory:
 
 ```ts
 new lambda.Function(this, 'MyFunction', {
   handler: 'index.handler',
   runtime: lambda.Runtime.NODEJS_10,
-  code: lambda.Code.fromAsset('./my-handler')
+  code: lambda.Code.fromAsset('./my-handler'),
 });
 ```
 
@@ -160,179 +212,245 @@ In order for this to work, this is what needs to happen:
 
 1. A zip archive needs to be created from the contents of `my-handler`.
 2. The file needs to be uploaded to an S3 bucket in the stack’s environment.
-3. The `Code` property in the synthesized `AWS::Lambda::Function` resource should point to the S3 URL that will contains this zip file when the stack
-   is deployed.
+3. The `Code` property in the synthesized `AWS::Lambda::Function` resource
+   should point to the S3 URL that will contains this zip file when the stack is
+   deployed.
 
-A similar set of requirements exist for a Docker image built from a local `Dockerfile`, pushed to an ECR repository in the target environment and
+A similar set of requirements exist for a Docker image built from a local
+`Dockerfile`, pushed to an ECR repository in the target environment and
 referenced in the `Image` property of the `AWS::ECS::TaskDefinition` resource.
 
 ### Asset Identity
 
-Assets will be identified throughout the system using a sha256 hash calculated from their source. This is the contents of the asset source directory,
-Dockerfile or specific file. Using a consistent source hash allows the various tools in the system to avoid duplicated work such as building docker
-images or transferring large amount of information.
+Assets will be identified throughout the system using a sha256 hash calculated
+from their source. This is the contents of the asset source directory,
+Dockerfile or specific file. Using a consistent source hash allows the various
+tools in the system to avoid duplicated work such as building docker images or
+transferring large amount of information.
 
-> **NOTE:** docker builds are technically not deterministic, but this scheme will cause them to be. If the source (Dockerfile or accompanying files)
-> didn’t change, the source hash will stay the same and the asset will not be rebuild/updated. Operationally this is actually a good thing as it will
-> protect against out-of-band updates (we only want commits to cause production updates), but users may rely on this non-deterministic behavior and we
-> need to communicate/enforce somehow.
+> **NOTE:** docker builds are technically not deterministic, but this scheme
+> will cause them to be. If the source (Dockerfile or accompanying files) didn’t
+> change, the source hash will stay the same and the asset will not be
+> rebuild/updated. Operationally this is actually a good thing as it will
+> protect against out-of-band updates (we only want commits to cause production
+> updates), but users may rely on this non-deterministic behavior and we need to
+> communicate/enforce somehow.
 
 ### Asset Stores
 
-The S3 bucket and ECR repository that are used to serve asset artifacts in each target environment are called the "**asset store**". They will be
-provisioned and populated **before** stacks which use assets can be deployed to this environment. The process of provisioning deployment resources in
-an AWS environment is called "**bootstrapping**". It provisions the asset store and various IAM roles with permissions to publish assets and to deploy
+The S3 bucket and ECR repository that are used to serve asset artifacts in each
+target environment are called the "**asset store**". They will be provisioned
+and populated **before** stacks which use assets can be deployed to this
+environment. The process of provisioning deployment resources in an AWS
+environment is called "**bootstrapping**". It provisions the asset store and
+various IAM roles with permissions to publish assets and to deploy
 CloudFormation stacks to the environment.
 
-In order to minimize the amount of configuration required throughout the deployment pipeline, we decided to double-down on the CDK design tenet that
-favors early (synthesis-time) binding. In the current implementation, if a CDK stack used asset, CloudFormation parameters are added to templates so
-that the asset locations were late-bound and resolved by the CLI only after the asset has been published. This approach has two problems:
+In order to minimize the amount of configuration required throughout the
+deployment pipeline, we decided to double-down on the CDK design tenet that
+favors early (synthesis-time) binding. In the current implementation, if a CDK
+stack used asset, CloudFormation parameters are added to templates so that the
+asset locations were late-bound and resolved by the CLI only after the asset has
+been published. This approach has two problems:
 
-1. It resulted in the proliferation of asset parameters (currently 2-3 parameters per asset).
-2. It requires the deployment tool to "wire" the asset parameters to the stack during deployment.
+1. It resulted in the proliferation of asset parameters (currently 2-3
+   parameters per asset).
+2. It requires the deployment tool to "wire" the asset parameters to the stack
+   during deployment.
 
-The main issue is #2. Different deployment tools have different ways to configure how parameters are passed to CloudFormation stacks, which makes it
-difficult to find a general purpose way to convey this information to the deployment stage. Additionally, the publishing and consumption locations
-must be customizable since different deployment systems may have different ways to publish and replicate assets across environments (for example, a
-deployment system which needs to be able to deploy to air-gapped regions and requires that all assets are published to a centralized store and then
-copied to target environments through air gaps).
+The main issue is #2. Different deployment tools have different ways to
+configure how parameters are passed to CloudFormation stacks, which makes it
+difficult to find a general purpose way to convey this information to the
+deployment stage. Additionally, the publishing and consumption locations must be
+customizable since different deployment systems may have different ways to
+publish and replicate assets across environments (for example, a deployment
+system which needs to be able to deploy to air-gapped regions and requires that
+all assets are published to a centralized store and then copied to target
+environments through air gaps).
 
-The solution is to resolve asset locations **during synthesis** and use naming conventions for bootstrapping resources. This means that asset
-locations will be concrete values and we can also encode all publishing information to the assembly manifest. It will also allow customizing all
-publishing behavior from within the CDK app, without the need to supply additional plugin capabilities.
+The solution is to resolve asset locations **during synthesis** and use naming
+conventions for bootstrapping resources. This means that asset locations will be
+concrete values and we can also encode all publishing information to the
+assembly manifest. It will also allow customizing all publishing behavior from
+within the CDK app, without the need to supply additional plugin capabilities.
 
-We will synthesize a file called `assets.json`, which will include preparation and publishing instructions for each asset.
+We will synthesize a file called `assets.json`, which will include preparation
+and publishing instructions for each asset.
 
-By default, S3 assets will be stored in a single S3 bucket where the object key will be based on the asset's source hash. Docker assets will be stored
-in a single ECR repository where the image tag will be based on the asset source hash (hash of the contents of the Dockerfile directory).
+By default, S3 assets will be stored in a single S3 bucket where the object key
+will be based on the asset's source hash. Docker assets will be stored in a
+single ECR repository where the image tag will be based on the asset source hash
+(hash of the contents of the Dockerfile directory).
 
 For file assets:
 
-* Source file or directory (relative to cloud assembly)
-* Packaging format (zip/file)
-* Destinations:
-  * Bucket name
-  * Object key
-  * Publishing Role ARN to assume
+- Source file or directory (relative to cloud assembly)
+- Packaging format (zip/file)
+- Destinations:
+  - Bucket name
+  - Object key
+  - Publishing Role ARN to assume
 
 For image assets:
 
-* Source directory (relative to cloud assembly): where Dockerfile resides
-* Docker build arguments (optional)
-* Dockerfile name (optional)
-* Destinations:
-  * ECR repository name
-  * Image name
-  * Publishing Role ARN to assume
+- Source directory (relative to cloud assembly): where Dockerfile resides
+- Docker build arguments (optional)
+- Dockerfile name (optional)
+- Destinations:
+  - ECR repository name
+  - Image name
+  - Publishing Role ARN to assume
 
 ### Customizability
 
-Asset consumption and publishing locations should be fully customizable. To that end, the `core.Stack` base class will expose an API that will be used
-by the asset framework to resolve consumption locations and synthesize `assets.json`. This will allow users to provide their own implementation based
-on their specific needs.
+Asset consumption and publishing locations should be fully customizable. To that
+end, the `core.Stack` base class will expose an API that will be used by the
+asset framework to resolve consumption locations and synthesize `assets.json`.
+This will allow users to provide their own implementation based on their
+specific needs.
 
 ### Asset Source Staging
 
-During synthesis, the CDK app will _copy the sources_ of all assets from their original location on disk into the cloud assembly output directory.
-This allows the cloud assembly to be self-contained and is important for the CI/CD use cases (both internal and external) where the cloud assembly is
-the only artifact needed after build is complete.
+During synthesis, the CDK app will _copy the sources_ of all assets from their
+original location on disk into the cloud assembly output directory. This allows
+the cloud assembly to be self-contained and is important for the CI/CD use cases
+(both internal and external) where the cloud assembly is the only artifact
+needed after build is complete.
 
 ### Asset Providers
 
-Users should be able to vend custom asset providers to allow customizing how assets are being referenced or packaged.
+Users should be able to vend custom asset providers to allow customizing how
+assets are being referenced or packaged.
 
-For example, a company might have an internal system that manages software artifacts. They can internally vend custom implementations for the
-`lambda.Code` and `ecs.ContainerImage` classes which will allow users to reference these artifacts and synthesize placeholders into the cloud
-assembly, which will later be resolved during the publishing stage and identified through a user-defined unique identifier.
+For example, a company might have an internal system that manages software
+artifacts. They can internally vend custom implementations for the `lambda.Code`
+and `ecs.ContainerImage` classes which will allow users to reference these
+artifacts and synthesize placeholders into the cloud assembly, which will later
+be resolved during the publishing stage and identified through a user-defined
+unique identifier.
 
 ### Environment-agnostic Stacks
 
 When a stack is defined, users can specify `env` (account and/or region).
 
-If `account` and/or `region` use the pseudo references `Aws.ACCOUNT_ID` and `Aws.REGION`, respectively, the stack is called "environment-agnostic".
-Certain features in the CDK, like VPC lookups for example, are not supported for environment-agnostic stacks since the specific account/region is
-required during synthesis.
+If `account` and/or `region` use the pseudo references `Aws.ACCOUNT_ID` and
+`Aws.REGION`, respectively, the stack is called "environment-agnostic". Certain
+features in the CDK, like VPC lookups for example, are not supported for
+environment-agnostic stacks since the specific account/region is required during
+synthesis.
 
-The proposal described in [PR#4131](https://github.com/aws/aws-cdk/pull/4131) suggests that environment-agnostics stacks cannot be deployed using the
-CDK. However, it also proposes that the default behavior for `env` will be to use ("inherit") the CLI configured environment when a stack is deployed
-through `cdk deploy`.
+The proposal described in [PR#4131](https://github.com/aws/aws-cdk/pull/4131)
+suggests that environment-agnostics stacks cannot be deployed using the CDK.
+However, it also proposes that the default behavior for `env` will be to use
+("inherit") the CLI configured environment when a stack is deployed through
+`cdk deploy`.
 
-This means that the only way to produce environment-agnostic templates will be to explicitly indicate it when a stack is defined.
+This means that the only way to produce environment-agnostic templates will be
+to explicitly indicate it when a stack is defined.
 
-Then `cdk-assets` will simply substitute `${AWS::ACCOUNT}` and `${AWS::REGION}` with the account and region derived from the credentials configured
-for the CLI.
+Then `cdk-assets` will simply substitute `${AWS::ACCOUNT}` and `${AWS::REGION}`
+with the account and region derived from the credentials configured for the CLI.
 
-> NOTE: even when an IAM role from another account is assumed for publishing, `${AWS::ACCOUNT}` and `${AWS::REGION}` always resolve to the CLI
-> configuration and not to the other account.
+> NOTE: even when an IAM role from another account is assumed for publishing,
+> `${AWS::ACCOUNT}` and `${AWS::REGION}` always resolve to the CLI configuration
+> and not to the other account.
 
 ## Bootstrapping
 
-The CDK already has a dedicated tool for bootstrapping environments called **`cdk bootstrap`**. An environment is bootstrapped once, and from that
-point, it is possible to deploy CDK apps into this environment.
+The CDK already has a dedicated tool for bootstrapping environments called
+**`cdk bootstrap`**. An environment is bootstrapped once, and from that point,
+it is possible to deploy CDK apps into this environment.
 
-Environment bootstrapping doesn't have to be performed by the development team, and does not require deep knowledge of the application structure,
-besides the set of accounts and regions into which the app needs to be deployed.
+Environment bootstrapping doesn't have to be performed by the development team,
+and does not require deep knowledge of the application structure, besides the
+set of accounts and regions into which the app needs to be deployed.
 
-The current implementation only provisions an S3 bucket, but in order to be able to continuously deploy CDK stacks that use asses, we will need the
-following resources __in each AWS environment (account + region)__:
+The current implementation only provisions an S3 bucket, but in order to be able
+to continuously deploy CDK stacks that use asses, we will need the following
+resources **in each AWS environment (account + region)**:
 
 For publishing:
 
-* **S3 Bucket (+ KMS resources)**: for file asset and CloudFormation template (a single bucket will contain all files keyed by their source hash)
-* **ECR Repository**: for all docker image assets (a single repo will contain all images tagged by their source hash).
-* **Publishing Role**: IAM role trusted by the deployment account, and allows publishing to the S3 bucket and the ECR repository.
+- **S3 Bucket (+ KMS resources)**: for file asset and CloudFormation template (a
+  single bucket will contain all files keyed by their source hash)
+- **ECR Repository**: for all docker image assets (a single repo will contain
+  all images tagged by their source hash).
+- **Publishing Role**: IAM role trusted by the deployment account, and allows
+  publishing to the S3 bucket and the ECR repository.
 
 For deployment:
 
-* **CloudFormation Role**: IAM role which allows the CloudFormation service principal to deploy stacks into the environment (this role usually has
+- **CloudFormation Role**: IAM role which allows the CloudFormation service
+  principal to deploy stacks into the environment (this role usually has
   administrative privileges).
-* **Deployment Role**: IAM role which allows anyone from the deployment account to create, update and describe CloudFormation change sets and "pass"
-  the CloudFormation role (`iam:PassRole`).
+- **Deployment Role**: IAM role which allows anyone from the deployment account
+  to create, update and describe CloudFormation change sets and "pass" the
+  CloudFormation role (`iam:PassRole`).
 
-To accommodate these requirements we will make the following changes to how `cdk bootstrap` works:
+To accommodate these requirements we will make the following changes to how
+`cdk bootstrap` works:
 
 1. Extend the bootstrap stack to include these resources.
 2. Use explicit convention-based physical names for all resources.
-3. Allow specifying a list of *trusted accounts* that can deploy to this account.
-4. Allow specifying the managed policy to use for the deployment role (mostly it will be the administrator managed policy).
-5. Allow specifying an optional qualifier for the physical names of all resources to address bucket hijacking concerns and allow multiple bootstraps
+3. Allow specifying a list of _trusted accounts_ that can deploy to this
+   account.
+4. Allow specifying the managed policy to use for the deployment role (mostly it
+   will be the administrator managed policy).
+5. Allow specifying an optional qualifier for the physical names of all
+   resources to address bucket hijacking concerns and allow multiple bootstraps
    to the same environment for whatever reason.
 
 ### Bootstrapping at Scale
 
-Since organizations may have to bootstrap thousands of accounts, we need to make sure we allow users to leverage "account stamping" tools such as [AWS
-CloudFormation StackSets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/what-is-cfnstacksets.html) and [AWS Control
-Tower](https://aws.amazon.com/controltower/). All of these tools are based on automatically and reliably deploying a single AWS CloudFormation
-template to multiple accounts across an organization.
+Since organizations may have to bootstrap thousands of accounts, we need to make
+sure we allow users to leverage "account stamping" tools such as
+[AWS CloudFormation StackSets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/what-is-cfnstacksets.html)
+and [AWS Control Tower](https://aws.amazon.com/controltower/). All of these
+tools are based on automatically and reliably deploying a single AWS
+CloudFormation template to multiple accounts across an organization.
 
-To make sure users can use these tools for bootstrapping, we will take the following requirements:
+To make sure users can use these tools for bootstrapping, we will take the
+following requirements:
 
-- Bootstrapping "logic" MUST be expressible through an AWS CloudFormation template.
-- Bootstrapping MUST be self-contained within an environment (account+region). We can't rely on the bootstrapping process to work across accounts or
-  regions.
-- Bootstrapping template size cannot exceed 50KiB so it can be deployed through the `TemplateBody` option of the CloudFormation `CreateStack` API (and
-  not require an S3 bucket).
-- Bootstrapping templates cannot rely on any other asset such as files on S3 or docker images.
+- Bootstrapping "logic" MUST be expressible through an AWS CloudFormation
+  template.
+- Bootstrapping MUST be self-contained within an environment (account+region).
+  We can't rely on the bootstrapping process to work across accounts or regions.
+- Bootstrapping template size cannot exceed 50KiB so it can be deployed through
+  the `TemplateBody` option of the CloudFormation `CreateStack` API (and not
+  require an S3 bucket).
+- Bootstrapping templates cannot rely on any other asset such as files on S3 or
+  docker images.
 
 ### Resource Names
 
-We need to be able to synthesize asset locations into the templates for consumption and publishing. We also need to be able to assume a role in order
-to be able to publish to the environment.
+We need to be able to synthesize asset locations into the templates for
+consumption and publishing. We also need to be able to assume a role in order to
+be able to publish to the environment.
 
-This means that we cannot rely on CloudFormation physical name generation since it requires accessing the account in order to resolve these names.
+This means that we cannot rely on CloudFormation physical name generation since
+it requires accessing the account in order to resolve these names.
 
-We will employ a naming convention which encodes `account`, `region` and an optional `qualifier` (such as `cdk-account-region[-qualifier]-xxxx`). This
-is because not all AWS resource names are environment-local: IAM roles are account-wide and S3 buckets are global.
+We will employ a naming convention which encodes `account`, `region` and an
+optional `qualifier` (such as `cdk-account-region[-qualifier]-xxxx`). This is
+because not all AWS resource names are environment-local: IAM roles are
+account-wide and S3 buckets are global.
 
-It is important that we do not rely on hashing or parsing account and region in order to be able to support account stamping tools like CloudFormation
-StackSets and Control Tower (in which case "account" resolves to `{ "Ref": "AWS::AccountId" }`, etc.
+It is important that we do not rely on hashing or parsing account and region in
+order to be able to support account stamping tools like CloudFormation StackSets
+and Control Tower (in which case "account" resolves to
+`{ "Ref": "AWS::AccountId" }`, etc.
 
-In order to address the risk of S3 bucket hijacking, we need to be able to support an optional `qualifier` postfix. This means that we need to allow
-users to specify this qualifier when they define the Stack's `env`. Perhaps we need to encode this into `aws://account/region[/qualifier]`
+In order to address the risk of S3 bucket hijacking, we need to be able to
+support an optional `qualifier` postfix. This means that we need to allow users
+to specify this qualifier when they define the Stack's `env`. Perhaps we need to
+encode this into `aws://account/region[/qualifier]`
 
-> **Alternative considered**: one way to implement environment-specific name-spacing would have been to export the bootstrapping resources through a
-> CloudFormation Export and then reference them using Fn::ImportValue. This would have worked for templates, but means that we would need a way to
-> resolve import values during publishing as well (and as a result also Fn::Join, etc).
+> **Alternative considered**: one way to implement environment-specific
+> name-spacing would have been to export the bootstrapping resources through a
+> CloudFormation Export and then reference them using Fn::ImportValue. This
+> would have worked for templates, but means that we would need a way to resolve
+> import values during publishing as well (and as a result also Fn::Join, etc).
 
 ### User Interface
 
@@ -344,8 +462,9 @@ WARNING: any principal from <ACCOUNT_ID> will have administrative access to the 
 Please confirm (Y/N):
 ```
 
-We should consider allowing users to specify a profile map that will allow bootstrapping multiple environments at the same time, but this can easily
-be achieved through a shell script:
+We should consider allowing users to specify a profile map that will allow
+bootstrapping multiple environments at the same time, but this can easily be
+achieved through a shell script:
 
 ```bash
 #!/bin/sh
@@ -355,47 +474,67 @@ cdk bootstrap --yes --profile prod-eu aws://222222222222/eu-west-2 --trust-accou
 
 ## Mutation
 
-Deployment of complex cloud application often involves a business-specific process which includes rolling out the app throughout multiple deployment
-phases and environments. This means that there is strong coupling between the structure of the application and the structure of its deployment
-pipeline. To enable users to represent this relationship naturally in their code, the CDK should support defining the app's deployment infrastructure
-as part of the CDK app.
+Deployment of complex cloud application often involves a business-specific
+process which includes rolling out the app throughout multiple deployment phases
+and environments. This means that there is strong coupling between the structure
+of the application and the structure of its deployment pipeline. To enable users
+to represent this relationship naturally in their code, the CDK should support
+defining the app's deployment infrastructure as part of the CDK app.
 
-Therefore, we recommend that all resources needed for the deployment pipeline are defined as part of the CDK app itself in one or more stacks. After
-synthesis, the cloud assembly will include a set of CloudFormation templates for the pipeline stack(s).
+Therefore, we recommend that all resources needed for the deployment pipeline
+are defined as part of the CDK app itself in one or more stacks. After
+synthesis, the cloud assembly will include a set of CloudFormation templates for
+the pipeline stack(s).
 
-We can't begin to deploy an app before we provision and update the required the deployment resources based on the structure of the app. This is the
-purpose of the "**mutation**" stage.
+We can't begin to deploy an app before we provision and update the required the
+deployment resources based on the structure of the app. This is the purpose of
+the "**mutation**" stage.
 
-The initial creation of the pipeline will be performed manually using `cdk deploy pipeline-main` (where `pipeline-main` is name of the main pipeline
-stack for example), but from that point forward, any changes to the pipeline will be done by pushing a commit into the repo, and letting the pipeline
-pick it up.
+The initial creation of the pipeline will be performed manually using
+`cdk deploy pipeline-main` (where `pipeline-main` is name of the main pipeline
+stack for example), but from that point forward, any changes to the pipeline
+will be done by pushing a commit into the repo, and letting the pipeline pick it
+up.
 
-For example, if we use CodePipeline for deploying an app to multiple environments, the deployment infrastructure requires a central pipeline stack,
-which contains the pipeline itself, it's artifacts bucket and other related resources such as CodeBuild projects. It will also require a stack in each
-region that includes a CodePipeline regional replication bucket (and key). See [cross-region
-support](https://docs.aws.amazon.com/codepipeline/latest/userguide/actions-create-cross-region.html) in the CodePipeline User Guide.
+For example, if we use CodePipeline for deploying an app to multiple
+environments, the deployment infrastructure requires a central pipeline stack,
+which contains the pipeline itself, it's artifacts bucket and other related
+resources such as CodeBuild projects. It will also require a stack in each
+region that includes a CodePipeline regional replication bucket (and key). See
+[cross-region support](https://docs.aws.amazon.com/codepipeline/latest/userguide/actions-create-cross-region.html)
+in the CodePipeline User Guide.
 
-In CodePipeline, we will implement self-mutation using a pre-configured CodeBuild action which runs `cdk deploy "pipeline-*"`. This will deploy all
-stacks that begin with the `pipeline-` prefix. These stacks can be deployed to any bootstrapped environment since `cdk deploy` can assume the
-deployment role.
+In CodePipeline, we will implement self-mutation using a pre-configured
+CodeBuild action which runs `cdk deploy "pipeline-*"`. This will deploy all
+stacks that begin with the `pipeline-` prefix. These stacks can be deployed to
+any bootstrapped environment since `cdk deploy` can assume the deployment role.
 
-To mitigate the security risk, `cdk deploy pipeline-*` should run against a synthesized cloud assembly (from the build step) and not against the
-executable app, and should also prohibit the use of docker assets. These are the two elements where user code is executed and must not be done in an
-environment with administrative privileges. The mutation CodeBuild action will not be customizable to ensure that users don't accidentally allow it to
-execute arbitrary code.
+To mitigate the security risk, `cdk deploy pipeline-*` should run against a
+synthesized cloud assembly (from the build step) and not against the executable
+app, and should also prohibit the use of docker assets. These are the two
+elements where user code is executed and must not be done in an environment with
+administrative privileges. The mutation CodeBuild action will not be
+customizable to ensure that users don't accidentally allow it to execute
+arbitrary code.
 
-> Alternative Considered: We initially considered leveraging the bootstrapping process in order to provision cross-regional replication resources for
-> CodePipeline but: (a) this is very specific to CodePipeline and not relevant to other deployment systems (e.g. Travis, GitHub Actions); and (b) it
-> will require the bootstrapping process to span more than a single environment. In order to allow users to use "account stamping" tools like Stack
-> Sets or Landing Zone, we decided that the bootstrapping process will be as simple as possible (== a single CloudFormation template).  The trade-off
-> is that for the CodePipeline resources, we will use `cdk deploy pipeline-*`, and so we can encode all this within the CDK. In fact cross
-> account/region is actually already supported in the CDK and will automatically define all these stacks and region for you, so it should already
-> "Just Work".
+> Alternative Considered: We initially considered leveraging the bootstrapping
+> process in order to provision cross-regional replication resources for
+> CodePipeline but: (a) this is very specific to CodePipeline and not relevant
+> to other deployment systems (e.g. Travis, GitHub Actions); and (b) it will
+> require the bootstrapping process to span more than a single environment. In
+> order to allow users to use "account stamping" tools like Stack Sets or
+> Landing Zone, we decided that the bootstrapping process will be as simple as
+> possible (== a single CloudFormation template). The trade-off is that for the
+> CodePipeline resources, we will use `cdk deploy pipeline-*`, and so we can
+> encode all this within the CDK. In fact cross account/region is actually
+> already supported in the CDK and will automatically define all these stacks
+> and region for you, so it should already "Just Work".
 
 ## Publishing
 
-The [`cdk-assets`](./cdk-assets.md) tool is responsible for _packaging_ and _publishing_ application assets to "**asset stores**" in AWS environments
-so they can be consumed by stacks deployed to these environments.
+The [`cdk-assets`](./cdk-assets.md) tool is responsible for _packaging_ and
+_publishing_ application assets to "**asset stores**" in AWS environments so
+they can be consumed by stacks deployed to these environments.
 
 See the [cdk-assets specification](./cdk-assets.md) for additional details.
 
@@ -403,66 +542,85 @@ See the [cdk-assets specification](./cdk-assets.md) for additional details.
 cdk-assets publish cdk.out [ASSET-ID,ASSET-ID,...]
 ```
 
-The input is the *cloud assembly* (`cdk.out`), which includes an asset manifest `assets.json`:
+The input is the _cloud assembly_ (`cdk.out`), which includes an asset manifest
+`assets.json`:
 
-The manifest is synthesized by the app and, for each asset (identified by their source hash) includes the `source` information (within the cloud
-assembly) and as set of `destinations` with a list of locations into which the asset should be published. The idea is that this manifest is all the
-information the publish needs.
+The manifest is synthesized by the app and, for each asset (identified by their
+source hash) includes the `source` information (within the cloud assembly) and
+as set of `destinations` with a list of locations into which the asset should be
+published. The idea is that this manifest is all the information the publish
+needs.
 
-A list of asset IDs (source hashes) can also be included in order to only publish a subset of the assets. This can be used to implement concurrent
+A list of asset IDs (source hashes) can also be included in order to only
+publish a subset of the assets. This can be used to implement concurrent
 publishing of assets (e.g. through CodePipeline).
 
 Then, for each asset, cdk-assets will perform the following operation:
 
 1. Assume the **publishing IAM role** in the target environment.
-2. Check if the asset is already published to this location. Assets are identified by their source hash. If it is, skip.
-3. If the asset doesn’t exists locally (e.g. docker image already exists, zip file already exists in local cache), package (docker build, zip
-   directory).
+2. Check if the asset is already published to this location. Assets are
+   identified by their source hash. If it is, skip.
+3. If the asset doesn’t exists locally (e.g. docker image already exists, zip
+   file already exists in local cache), package (docker build, zip directory).
 4. Publish the asset to the target location.
 
-In order for the publish to be able to execute `docker build`, this command must be executed in an environment that has docker available (in CodeBuild
-this means the project must be "privileged").
+In order for the publish to be able to execute `docker build`, this command must
+be executed in an environment that has docker available (in CodeBuild this means
+the project must be "privileged").
 
-[Caching of docker layers](https://docs.aws.amazon.com/codebuild/latest/userguide/build-caching.html#caching-local) is supported by CodeBuild and
-therefore `--ci` feature we have today in the CDK which pulls the `latest` tag of images before docker builds is not required. Furthermore, since
-images will now be identified only by their source hash (and not by their construct node ID) means that it will be impossible to pull a "latest"
-version.
+[Caching of docker layers](https://docs.aws.amazon.com/codebuild/latest/userguide/build-caching.html#caching-local)
+is supported by CodeBuild and therefore `--ci` feature we have today in the CDK
+which pulls the `latest` tag of images before docker builds is not required.
+Furthermore, since images will now be identified only by their source hash (and
+not by their construct node ID) means that it will be impossible to pull a
+"latest" version.
 
 ### Templates as Assets
 
-Some deployment systems (e.g. the CDK CLI and other systems we explored) require that CloudFormation templates will be uploaded an S3 location before
-they can be deployed (this is done automatically in CodePipeline). Due to S3 eventual consistency, these files must be immutable, so we need to upload
-a new template file every time the template changes.
+Some deployment systems (e.g. the CDK CLI and other systems we explored) require
+that CloudFormation templates will be uploaded an S3 location before they can be
+deployed (this is done automatically in CodePipeline). Due to S3 eventual
+consistency, these files must be immutable, so we need to upload a new template
+file every time the template changes.
 
-To that end, we will treat all CloudFormation templates in the assembly like any other asset. They will be identified by their source hash (the hash
-of the template) and uploaded to the asset store in the environment in which they are expected to be deployed, like any other file asset.
+To that end, we will treat all CloudFormation templates in the assembly like any
+other asset. They will be identified by their source hash (the hash of the
+template) and uploaded to the asset store in the environment in which they are
+expected to be deployed, like any other file asset.
 
 ## Deployment
 
-At this point, all assets are published to asset stores in their target environments, so we can simply use standard CloudFormation deployment tools to
-deploy templates from the cloud assembly. Any references to assets were already resolved during synthesis.
+At this point, all assets are published to asset stores in their target
+environments, so we can simply use standard CloudFormation deployment tools to
+deploy templates from the cloud assembly. Any references to assets were already
+resolved during synthesis.
 
 To deploy a stack to an environment, the deployment will need to:
 
-1. Assume the **Deployment IAM Role** from the target environment. The deployment IAM role is encoded inside the cloud assembly. By default the name
-   of the role is rendered by `core.Stack` based on the conventions of the bootstrapping template, but users are able to override this behavior if
-   their environments used custom bootstrapping.
+1. Assume the **Deployment IAM Role** from the target environment. The
+   deployment IAM role is encoded inside the cloud assembly. By default the name
+   of the role is rendered by `core.Stack` based on the conventions of the
+   bootstrapping template, but users are able to override this behavior if their
+   environments used custom bootstrapping.
 2. Create a CloudFormation change-set for the stack.
-3. Execute the change-set by requesting CloudFormation to assume the administrative **CloudFormation IAM Role** (again, role is encoded in the cloud
-   assembly).
+3. Execute the change-set by requesting CloudFormation to assume the
+   administrative **CloudFormation IAM Role** (again, role is encoded in the
+   cloud assembly).
 
-> This step intentionally uses the most standard CloudFormation deployment actions. This means that users will be able to implement custom flows that
-> leverages these building blocks in any way they need. For example, they can incorporate a manual approval step between changeset creation and
-> execution.
+> This step intentionally uses the most standard CloudFormation deployment
+> actions. This means that users will be able to implement custom flows that
+> leverages these building blocks in any way they need. For example, they can
+> incorporate a manual approval step between changeset creation and execution.
 
 ## Walkthrough
 
-In this section we will walk through the process of deploying a complex CDK app and how each one of the components in the toolchain is used within the
-workflow.
+In this section we will walk through the process of deploying a complex CDK app
+and how each one of the components in the toolchain is used within the workflow.
 
 ### Bootstrapping
 
-We go to our ops team and ask them to prepare three AWS accounts for our application:
+We go to our ops team and ask them to prepare three AWS accounts for our
+application:
 
 1. `111111111DEP`: Deployment account
 2. `2222222222US`: US account
@@ -476,77 +634,107 @@ $ cdk bootstrap aws://2222222222US/us-east-1 --trust-account 111111111DEP
 $ cdk bootstrap aws://3333333333EU/eu-west-2 --trust-account 111111111DEP
 ```
 
-> NOTE: each bootstrap command will be executed with the appropriate AWS credentials configured.
+> NOTE: each bootstrap command will be executed with the appropriate AWS
+> credentials configured.
 
 The bootstrapping process will create the following resources:
 
-* 111111111DEP/us-west-2:
-  * `aws-cdk-files-111111111DEP-us-west-2`: S3 bucket
-  * `aws-cdk-images-111111111DEP-us-west-2`: ECR repository
-  * `aws-cdk-publish-111111111DEP-us-west-2`: IAM role for publishing (assumable by 111111111DEP), permissions to read/write from the S3/ECR
-  * `aws-cdk-deploy-111111111DEP-us-west-2`: IAM role for deployment (assumable by 111111111DEP), with pass-role to the CloudFormation role
-  * `aws-cdk-admin-111111111DEP-us-west-2`: IAM role for CloudFormation (assumable by the CloudFormation service principal)
-* 2222222222US/us-east-1:
-  * `aws-cdk-files-2222222222EU-us-east-1`: S3 bucket
-  * `aws-cdk-images-2222222222EU-us-east-1`: ECR repository
-  * `aws-cdk-publish-2222222222EU-us-east-1`: IAM role for publishing (assumable by 111111111DEP), permissions to read/write from the S3/ECR
-  * `aws-cdk-deploy-2222222222EU-us-east-1`: IAM role for deployment (assumable by 111111111DEP), with pass-role to the CloudFormation role
-  * `aws-cdk-admin-2222222222EU-us-east-1`: IAM role for CloudFormation (assumable by the CloudFormation service principal)
-* 3333333333EU/eu-west-2:
-  * `aws-cdk-files-3333333333EU-eu-west-2`: S3 bucket
-  * `aws-cdk-images-3333333333EU-eu-west-2`: ECR repository
-  * `aws-cdk-publish-3333333333EU-eu-west-2`: IAM role for publishing (assumable by 111111111DEP), permissions to read/write from the S3/ECR
-  * `aws-cdk-deploy-3333333333EU-eu-west-2`: IAM role for deployment (assumable by 111111111DEP), with pass-role to the CloudFormation role
-  * `aws-cdk-admin-3333333333EU-eu-west-2`: IAM role for CloudFormation (assumable by the CloudFormation service principal)
+- 111111111DEP/us-west-2:
+  - `aws-cdk-files-111111111DEP-us-west-2`: S3 bucket
+  - `aws-cdk-images-111111111DEP-us-west-2`: ECR repository
+  - `aws-cdk-publish-111111111DEP-us-west-2`: IAM role for publishing (assumable
+    by 111111111DEP), permissions to read/write from the S3/ECR
+  - `aws-cdk-deploy-111111111DEP-us-west-2`: IAM role for deployment (assumable
+    by 111111111DEP), with pass-role to the CloudFormation role
+  - `aws-cdk-admin-111111111DEP-us-west-2`: IAM role for CloudFormation
+    (assumable by the CloudFormation service principal)
+- 2222222222US/us-east-1:
+  - `aws-cdk-files-2222222222EU-us-east-1`: S3 bucket
+  - `aws-cdk-images-2222222222EU-us-east-1`: ECR repository
+  - `aws-cdk-publish-2222222222EU-us-east-1`: IAM role for publishing (assumable
+    by 111111111DEP), permissions to read/write from the S3/ECR
+  - `aws-cdk-deploy-2222222222EU-us-east-1`: IAM role for deployment (assumable
+    by 111111111DEP), with pass-role to the CloudFormation role
+  - `aws-cdk-admin-2222222222EU-us-east-1`: IAM role for CloudFormation
+    (assumable by the CloudFormation service principal)
+- 3333333333EU/eu-west-2:
+  - `aws-cdk-files-3333333333EU-eu-west-2`: S3 bucket
+  - `aws-cdk-images-3333333333EU-eu-west-2`: ECR repository
+  - `aws-cdk-publish-3333333333EU-eu-west-2`: IAM role for publishing (assumable
+    by 111111111DEP), permissions to read/write from the S3/ECR
+  - `aws-cdk-deploy-3333333333EU-eu-west-2`: IAM role for deployment (assumable
+    by 111111111DEP), with pass-role to the CloudFormation role
+  - `aws-cdk-admin-3333333333EU-eu-west-2`: IAM role for CloudFormation
+    (assumable by the CloudFormation service principal)
 
-Notice that all bootstrapping resources have conventional physical names so asset locations can be resolved during synthesis without needing to access
-the accounts.
+Notice that all bootstrapping resources have conventional physical names so
+asset locations can be resolved during synthesis without needing to access the
+accounts.
 
 ### Source
 
-This section describes the sample app we will use for our walkthrough in order to demonstrate how the various pieces work together.
+This section describes the sample app we will use for our walkthrough in order
+to demonstrate how the various pieces work together.
 
-Our app needs to be deployed to two geographies: US (in us-east-1) and EU (in eu-west-2).
+Our app needs to be deployed to two geographies: US (in us-east-1) and EU (in
+eu-west-2).
 
-In each geography, we will split our app into two stacks: one that includes the VPC resources (`vpc-us` and `vpc-eu`) and the other that includes the
-service resources (`service-us` and `service-eu`). This is just an example of course, apps should be able to define any layout they desire.
+In each geography, we will split our app into two stacks: one that includes the
+VPC resources (`vpc-us` and `vpc-eu`) and the other that includes the service
+resources (`service-us` and `service-eu`). This is just an example of course,
+apps should be able to define any layout they desire.
 
-The service stack will use two assets: one docker image created from a Dockerfile in our project and one zip file created from a directory.
+The service stack will use two assets: one docker image created from a
+Dockerfile in our project and one zip file created from a directory.
 
-Deployment resources (pipeline, buckets, etc) will be defined in a separate set of stacks (`pipeline-main`, `pipeline-us-east-1` and
-`pipeline-eu-west-2`). The pipeline has the following stages:
+Deployment resources (pipeline, buckets, etc) will be defined in a separate set
+of stacks (`pipeline-main`, `pipeline-us-east-1` and `pipeline-eu-west-2`). The
+pipeline has the following stages:
 
 1. Source: monitors a git repository and kicks off the pipeline.
-2. Build: a CodeBuild action which compiles the app and invokes `cdk synth`. The output artifact is `cdk.out`.
-3. Mutate: a CodeBuild action which runs `cdk deploy pipeline-*` to update all pipeline stacks
-4. Publish: includes a CodeBuild action for each asset (2 in our case) which runs `cdk-publish ASSET_ID`
-5. VPC Deployment Stage: includes two cross-environment CloudFormation deployment actions for deploying the VPC stack to US and EU
-6. Service Deployment Stage: includes two cross-environment CloudFormation deployment actions for deploying the service stack to US and EU
+2. Build: a CodeBuild action which compiles the app and invokes `cdk synth`. The
+   output artifact is `cdk.out`.
+3. Mutate: a CodeBuild action which runs `cdk deploy pipeline-*` to update all
+   pipeline stacks
+4. Publish: includes a CodeBuild action for each asset (2 in our case) which
+   runs `cdk-publish ASSET_ID`
+5. VPC Deployment Stage: includes two cross-environment CloudFormation
+   deployment actions for deploying the VPC stack to US and EU
+6. Service Deployment Stage: includes two cross-environment CloudFormation
+   deployment actions for deploying the service stack to US and EU
 
 NOTES:
 
-* The "Build" stage is defined by the user and expected to always have `cdk.out` as the output artifact (by convention).
-* The "Mutate" and "Publish" stage will be provided as ready-made building blocks
-* The order and structure of the "Deployment" stages are just an example. Users may choose the orchestration they need.
-* The AWS CodePipeline module in the CDK will automatically define all auxiliary stacks required for the pipeline based on the actual structure
+- The "Build" stage is defined by the user and expected to always have `cdk.out`
+  as the output artifact (by convention).
+- The "Mutate" and "Publish" stage will be provided as ready-made building
+  blocks
+- The order and structure of the "Deployment" stages are just an example. Users
+  may choose the orchestration they need.
+- The AWS CodePipeline module in the CDK will automatically define all auxiliary
+  stacks required for the pipeline based on the actual structure
   (`pipeline-REGION`).
 
 ### Synthesis
 
-After the app is compiled, `cdk synth` will produce a `cdk.out` directory (cloud assembly) which includes the following files:
+After the app is compiled, `cdk synth` will produce a `cdk.out` directory (cloud
+assembly) which includes the following files:
 
 1. `manifest.json`
 2. `assets.json`
 3. `pipeline-main.template.json`: the pipeline itself and auxiliary resources
-4. `pipeline-us-east-1.template.json`: pipeline replication resources needed for US deployment
-5. `pipeline-eu-west-2.template.json`: pipeline replication resources needed for EU deployment
+4. `pipeline-us-east-1.template.json`: pipeline replication resources needed for
+   US deployment
+5. `pipeline-eu-west-2.template.json`: pipeline replication resources needed for
+   EU deployment
 6. `vpc-us.template.json`: VPC stack for the US deployment
 7. `vpc-eu.template.json`: VPC stack for the EU deployment
 8. `service-us.template.json`: service stack for the US deployment
 9. `service-eu.template.json`: service stack for the EU deployment
 
-The `manifest.json` file will include an entry for each stack defined above (like today), but each stack will also include the IAM roles to assume if
-you wish to deploy this stack:
+The `manifest.json` file will include an entry for each stack defined above
+(like today), but each stack will also include the IAM roles to assume if you
+wish to deploy this stack:
 
 ```json
 {
@@ -670,56 +858,75 @@ The `assets.json` file will look like this:
 }
 ```
 
-It lists the two assets (one file asset and one image asset) and, for each, it lists the publishing locations which include repository, key and
-publishing IAM role to assume.
+It lists the two assets (one file asset and one image asset) and, for each, it
+lists the publishing locations which include repository, key and publishing IAM
+role to assume.
 
 ### Pipeline Initialization
 
-At this point we have a bunch of bootstrapped environments and a local `cdk.out` directory. In order to deploy our self-mutating CI/CD pipeline for
-the app, we need to perform a single, one-off, manual operation:
+At this point we have a bunch of bootstrapped environments and a local `cdk.out`
+directory. In order to deploy our self-mutating CI/CD pipeline for the app, we
+need to perform a single, one-off, manual operation:
 
 ```console
 $ cdk deploy "pipeline-*"
 ```
 
-Running this manually will deploy our pipeline which monitors our source control. From now on, any chances to our pipeline will be done by pushing
+Running this manually will deploy our pipeline which monitors our source
+control. From now on, any chances to our pipeline will be done by pushing
 commits into our source repository and not through the CDK CLI.
 
 ### Mutation
 
-The first stage in our pipeline is the mutation stage. This stage will include a single CodeBuild action that will simply execute: `cdk deploy pipeline-*`.
+The first stage in our pipeline is the mutation stage. This stage will include a
+single CodeBuild action that will simply execute: `cdk deploy pipeline-*`.
 
-This will update all the stacks with names that begin with "pipeline-". Namely, it includes the pipeline stack itself, and the auxiliary stacks that
-include the pipeline's regional replication buckets. Since we are using `cdk deploy` here, we can technically deploy any stack to any environment in
-this stage because `cdk deploy` can assume the deployment role in any of the environments which trust the deployment account.
+This will update all the stacks with names that begin with "pipeline-". Namely,
+it includes the pipeline stack itself, and the auxiliary stacks that include the
+pipeline's regional replication buckets. Since we are using `cdk deploy` here,
+we can technically deploy any stack to any environment in this stage because
+`cdk deploy` can assume the deployment role in any of the environments which
+trust the deployment account.
 
-> In the [CodePipeline Cross Account Reference Architecture](https://github.com/awslabs/aws-refarch-cross-account-pipeline) the "deployment account"
-> is known as the "tools account".
+> In the
+> [CodePipeline Cross Account Reference Architecture](https://github.com/awslabs/aws-refarch-cross-account-pipeline)
+> the "deployment account" is known as the "tools account".
 
-Notice that this stage happens **before** the publish stage. This is because the structure of the publish stage is dependent on which assets the app
-uses (we synthesize an action per asset for maximal parallelism), so we want to make sure the pipeline will be updated before publishing.
+Notice that this stage happens **before** the publish stage. This is because the
+structure of the publish stage is dependent on which assets the app uses (we
+synthesize an action per asset for maximal parallelism), so we want to make sure
+the pipeline will be updated before publishing.
 
-> NOTE: if there is a constraint that does not allow the pipeline to be updated before publishing, it simply means that we have to publish all assets
-> from a single action (`cdk-assets publish cdk.out`).
+> NOTE: if there is a constraint that does not allow the pipeline to be updated
+> before publishing, it simply means that we have to publish all assets from a
+> single action (`cdk-assets publish cdk.out`).
 
 In our example, there are 3 pipeline stacks:
 
-1. `pipeline-main`: contains the pipeline resource, the main artifacts bucket and other related resources
-2. `pipeline-us-east-1`: contains the pipeline replication bucket and key for us-east-1
-3. `pipeline-eu-west-2`: contains the pipeline replication bucket and key for eu-west-2
+1. `pipeline-main`: contains the pipeline resource, the main artifacts bucket
+   and other related resources
+2. `pipeline-us-east-1`: contains the pipeline replication bucket and key for
+   us-east-1
+3. `pipeline-eu-west-2`: contains the pipeline replication bucket and key for
+   eu-west-2
 
-Once we deploy these stacks, our pipeline will be ready to deploy the rest of our app.
+Once we deploy these stacks, our pipeline will be ready to deploy the rest of
+our app.
 
 ### Publishing
 
 The next stage in the process is the publishing stage.
 
-In our example, this stage will consist of two CodeBuild actions that will run the following commands concurrently. These command will package &
-upload the asset to all the environments. It will consult `assets.json` to determine the exact location into which to publish each asset and which
-cross-account role to assume.
+In our example, this stage will consist of two CodeBuild actions that will run
+the following commands concurrently. These command will package & upload the
+asset to all the environments. It will consult `assets.json` to determine the
+exact location into which to publish each asset and which cross-account role to
+assume.
 
-> The CodePipeline stage that includes all the asset publishing actions will be automatically generated based on the application structure. This means
-> that any new assets added to the app will automatically appear in this pipeline stage as new CodeBuild actions.
+> The CodePipeline stage that includes all the asset publishing actions will be
+> automatically generated based on the application structure. This means that
+> any new assets added to the app will automatically appear in this pipeline
+> stage as new CodeBuild actions.
 
 The first action will run this command:
 
@@ -727,8 +934,10 @@ The first action will run this command:
 cdk-assets publish cdk.out d31ca1aef8d1b68217852e7aea70b1e857d107b47637d5160f9f9a1b24882d2a
 ```
 
-This will build the docker image from `cdk.out/my-image` using `CustomDockerFile` as a dockerfile. Then, it will assume the roles in the destinations
-specified in `assets.json` and push the image to the specified ECR locations.
+This will build the docker image from `cdk.out/my-image` using
+`CustomDockerFile` as a dockerfile. Then, it will assume the roles in the
+destinations specified in `assets.json` and push the image to the specified ECR
+locations.
 
 The second action will run this command:
 
@@ -736,100 +945,129 @@ The second action will run this command:
 cdk-assets publish cdk.out a0bae29e7b47044a66819606c65d26a92b1e844f4b3124a5539efc0167a09e57
 ```
 
-This will create a zip archive from the files under `asset.a0bae29e7b47044a66819606c65d26a92b1e844f4b3124a5539efc0167a09e57`, and then will assume the
-roles and upload the file to the destination S3 locations.
+This will create a zip archive from the files under
+`asset.a0bae29e7b47044a66819606c65d26a92b1e844f4b3124a5539efc0167a09e57`, and
+then will assume the roles and upload the file to the destination S3 locations.
 
 ### Deployment
 
-Once publishing is complete, we can commence deployment. Deployment can happen at any desired order and use the standard CloudFormation deployment
-actions.
+Once publishing is complete, we can commence deployment. Deployment can happen
+at any desired order and use the standard CloudFormation deployment actions.
 
-Each action will be responsible to deploy a single stack to a specific environment. The input artifact will be the cloud assembly, and the template
+Each action will be responsible to deploy a single stack to a specific
+environment. The input artifact will be the cloud assembly, and the template
 file name will be the template
 
-In our example, we decided to first deploy the VPC stack to all geographies and then deploy the service stack, so we will have two deployment stages,
-each one with two CloudFormation deployment actions.
+In our example, we decided to first deploy the VPC stack to all geographies and
+then deploy the service stack, so we will have two deployment stages, each one
+with two CloudFormation deployment actions.
 
-All actions will use `cdk.out` as their input artifact, with the specified template name, account, region, deploy and CloudFormation IAM roles.
+All actions will use `cdk.out` as their input artifact, with the specified
+template name, account, region, deploy and CloudFormation IAM roles.
 
-CodePipeline will use the regional replication buckets to transfer cdk.out to the destination regions and then assume the deployment role that will
-invoke the CloudFormation API, passing it the CloudFormation role.
+CodePipeline will use the regional replication buckets to transfer cdk.out to
+the destination regions and then assume the deployment role that will invoke the
+CloudFormation API, passing it the CloudFormation role.
 
 That's it basically.
 
 ## Compatibility Plan
 
-This section describes how we plan to implement this new model, while still supporting old CLIs, apps written with old frameworks and old bootstrap
+This section describes how we plan to implement this new model, while still
+supporting old CLIs, apps written with old frameworks and old bootstrap
 environments.
 
 This design requires disruptive changes to the following components:
 
-- **Bootstrap Stack**: the contents of the environment's bootstrap stack has changed. It now includes additional resources like an ECR repository and
-  IAM role, and also uses conventional physical names.
-- **Assets (Framework)**: currently each asset synthesizes a set of CloudFormation parameter that is then assigned by the CLI during deployment, and
-  assets are described as metadata in the cloud assembly manifest. This design stipulates that assets will always be published to well-known locations
-  (based on the bootstrap stack conventions) and described in the `assets.json` manifest which is consumed by `cdk-assets`.
-- **Publishing (CLI)**: currently the CLI conflates both asset publishing and deployment into a single step. This design stipulates that `cdk-assets`
+- **Bootstrap Stack**: the contents of the environment's bootstrap stack has
+  changed. It now includes additional resources like an ECR repository and IAM
+  role, and also uses conventional physical names.
+- **Assets (Framework)**: currently each asset synthesizes a set of
+  CloudFormation parameter that is then assigned by the CLI during deployment,
+  and assets are described as metadata in the cloud assembly manifest. This
+  design stipulates that assets will always be published to well-known locations
+  (based on the bootstrap stack conventions) and described in the `assets.json`
+  manifest which is consumed by `cdk-assets`.
+- **Publishing (CLI)**: currently the CLI conflates both asset publishing and
+  deployment into a single step. This design stipulates that `cdk-assets`
   manages all asset publishing and the CLI is only responsible for deployment.
-- **AdoptedRepository**: The new asset mechanism does not require Docker image assets to be backed by `AdoptedRepository` since the ECR repository in
-  the new bootstrap stack will allow anyone to read from it.
-- **Deployment Roles**: In the new mode, the cloud assembly manifest also includes IAM roles for deployment. These only exist in the new model, and
+- **AdoptedRepository**: The new asset mechanism does not require Docker image
+  assets to be backed by `AdoptedRepository` since the ECR repository in the new
+  bootstrap stack will allow anyone to read from it.
+- **Deployment Roles**: In the new mode, the cloud assembly manifest also
+  includes IAM roles for deployment. These only exist in the new model, and
   should cause the CLI to assume these roles during depoyment.
 
 ### Goal
 
-Existing applications should continue to seamlessly work in any combination of CLI/framework without any forced modification when suppot for these new
+Existing applications should continue to seamlessly work in any combination of
+CLI/framework without any forced modification when suppot for these new
 capabilities is introduced.
 
-Obvsiouly, if users wish to leverage the new CDK continuous delivery capabilities, they will have to upgrade all three components (bootstrap stack,
-framework, CLI). It's important that their experience will be guided (i.e. they will be promoted exactly what they need to do and not simply get
-cryptic error messages).
+Obvsiouly, if users wish to leverage the new CDK continuous delivery
+capabilities, they will have to upgrade all three components (bootstrap stack,
+framework, CLI). It's important that their experience will be guided (i.e. they
+will be promoted exactly what they need to do and not simply get cryptic error
+messages).
 
 ### Approach
 
-The main implication is that both CLI and framework should continue to support the "legacy mode" which controls all relevant behavior: asset synthesis
-(including `AdoptedRepository`), deployment roles and any other aspect described in this design.
+The main implication is that both CLI and framework should continue to support
+the "legacy mode" which controls all relevant behavior: asset synthesis
+(including `AdoptedRepository`), deployment roles and any other aspect described
+in this design.
 
-The following table describes the desired behavior for each combination of CLI version, framework version and whether this is an existing app or a new
-app (the result of `cdk init` from a new CLI):
+The following table describes the desired behavior for each combination of CLI
+version, framework version and whether this is an existing app or a new app (the
+result of `cdk init` from a new CLI):
 
-| #  |      | CLI  | Framework | Bootstrap | App | Mode | Comments
-|----|------|------|-----------|-----------|-----|------|----------------------
-| 0  | 0000 | OLD  | OLD       | OLD       | OLD | 1.0  | No change
-| 1  | 0001 | OLD  | OLD       | OLD       | NEW | 1.0  | App created with old CLI
-| 2  | 0010 | OLD  | OLD       | NEW       | OLD | 1.0  | "Run `cdk bootstrap`"
-| 3  | 0011 | OLD  | OLD       | NEW       | NEW | 1.0  | new bootstrap stack is not detectable
-| 4  | 0100 | OLD  | NEW       | OLD       | OLD | 1.0  | Framework auto-detects old CLI
-| 5  | 0101 | OLD  | NEW       | OLD       | NEW | ERR  | "please upgrade your CLI and bootstrap"
-| 6  | 0110 | OLD  | NEW       | NEW       | OLD | 1.0  | "Run `cdk bootstrap`"
-| 7  | 0111 | OLD  | NEW       | NEW       | NEW | ERR  | "please upgrade your CLI"
-| 8  | 1000 | NEW  | OLD       | OLD       | OLD | 1.0  | CLI auto-detects old framework
-| 9  | 1001 | NEW  | OLD       | OLD       | NEW | 1.0  | CLI auto-detects old framework
-| 10 | 1010 | NEW  | OLD       | NEW       | OLD | 1.0  | <span style="color:red">can this work??</span>
-| 11 | 1011 | NEW  | OLD       | NEW       | NEW | 1.0  | Old framework doesn't respect feature flag
-| 12 | 1100 | NEW  | NEW       | OLD       | OLD | 1.0  | Can opt-in to 2.0
-| 13 | 1101 | NEW  | NEW       | OLD       | NEW | 2.0  | "Run `cdk bootstrap`"
-| 14 | 1110 | NEW  | NEW       | NEW       | OLD |      | <span style="color:red">can this work??</span>
-| 15 | 1111 | NEW  | NEW       | NEW       | NEW | 2.0  | Final state
+| #   |      | CLI | Framework | Bootstrap | App | Mode | Comments                                       |
+| --- | ---- | --- | --------- | --------- | --- | ---- | ---------------------------------------------- |
+| 0   | 0000 | OLD | OLD       | OLD       | OLD | 1.0  | No change                                      |
+| 1   | 0001 | OLD | OLD       | OLD       | NEW | 1.0  | App created with old CLI                       |
+| 2   | 0010 | OLD | OLD       | NEW       | OLD | 1.0  | "Run `cdk bootstrap`"                          |
+| 3   | 0011 | OLD | OLD       | NEW       | NEW | 1.0  | new bootstrap stack is not detectable          |
+| 4   | 0100 | OLD | NEW       | OLD       | OLD | 1.0  | Framework auto-detects old CLI                 |
+| 5   | 0101 | OLD | NEW       | OLD       | NEW | ERR  | "please upgrade your CLI and bootstrap"        |
+| 6   | 0110 | OLD | NEW       | NEW       | OLD | 1.0  | "Run `cdk bootstrap`"                          |
+| 7   | 0111 | OLD | NEW       | NEW       | NEW | ERR  | "please upgrade your CLI"                      |
+| 8   | 1000 | NEW | OLD       | OLD       | OLD | 1.0  | CLI auto-detects old framework                 |
+| 9   | 1001 | NEW | OLD       | OLD       | NEW | 1.0  | CLI auto-detects old framework                 |
+| 10  | 1010 | NEW | OLD       | NEW       | OLD | 1.0  | <span style="color:red">can this work??</span> |
+| 11  | 1011 | NEW | OLD       | NEW       | NEW | 1.0  | Old framework doesn't respect feature flag     |
+| 12  | 1100 | NEW | NEW       | OLD       | OLD | 1.0  | Can opt-in to 2.0                              |
+| 13  | 1101 | NEW | NEW       | OLD       | NEW | 2.0  | "Run `cdk bootstrap`"                          |
+| 14  | 1110 | NEW | NEW       | NEW       | OLD |      | <span style="color:red">can this work??</span> |
+| 15  | 1111 | NEW | NEW       | NEW       | NEW | 2.0  | Final state                                    |
 
 ### Requirements
 
-The CLI must auto-detect the assembly format version of the synthesized app based on heuristics `assets.json` or asset metadata in manifest (perhaps
-we will just bump the assembly manifest version number). Based on this version it will execute either the legacy (1.0) code path or the new code path.
-If the old code path is required, the old bootstrap behavior will be expected. If the bootstrap stack
+The CLI must auto-detect the assembly format version of the synthesized app
+based on heuristics `assets.json` or asset metadata in manifest (perhaps we will
+just bump the assembly manifest version number). Based on this version it will
+execute either the legacy (1.0) code path or the new code path. If the old code
+path is required, the old bootstrap behavior will be expected. If the bootstrap
+stack
 
-The framework will use the CLI version information passed in through environment variable to detect an old CLI.
+The framework will use the CLI version information passed in through environment
+variable to detect an old CLI.
 
-A new feature flag `cloud-assembly-version` will be used to determine the cloud assembly format version the framework operates in. This flag will
-front all relevant code paths.
+A new feature flag `cloud-assembly-version` will be used to determine the cloud
+assembly format version the framework operates in. This flag will front all
+relevant code paths.
 
-In order to enable case #6 (new CLI + framework with old app), the default for `cloud-assembly-version` will be `1.0` (legacy). This means old apps
-that upgrade both CLI and framework to new version will continue to function without any change. If old apps wishes to use the new behavior, they will
-have to explicitly specify `cloud-assembly-version` in their `cdk.json` (or code).
+In order to enable case #6 (new CLI + framework with old app), the default for
+`cloud-assembly-version` will be `1.0` (legacy). This means old apps that
+upgrade both CLI and framework to new version will continue to function without
+any change. If old apps wishes to use the new behavior, they will have to
+explicitly specify `cloud-assembly-version` in their `cdk.json` (or code).
 
-However, we still want new CDK apps created using `cdk init` to use the new behavior (case #9). To that end, when `cdk init` will be executed from a
-new CLI, the `cdk.json` it will generate will pass in `cloud-assembly-version: 2.0`. This basically means that new apps will automatically be opted-in
-to this new behavior.
+However, we still want new CDK apps created using `cdk init` to use the new
+behavior (case #9). To that end, when `cdk init` will be executed from a new
+CLI, the `cdk.json` it will generate will pass in `cloud-assembly-version: 2.0`.
+This basically means that new apps will automatically be opted-in to this new
+behavior.
 
-If old CLI is used and the app is configured to use 2.0 (#3), an error will be raised (we could technically fall back to 1.0 but there is probably no
+If old CLI is used and the app is configured to use 2.0 (#3), an error will be
+raised (we could technically fall back to 1.0 but there is probably no
 sufficient value).

--- a/text/0055-feature-flags.md
+++ b/text/0055-feature-flags.md
@@ -1,7 +1,7 @@
 ---
-feature name: feature-flags 
-start date: 
-rfc pr: https://github.com/aws/aws-cdk/pull/5017 
+feature name: feature-flags
+? start date
+rfc pr: https://github.com/aws/aws-cdk/pull/5017
 related issue: https://github.com/awslabs/aws-cdk-rfcs/issues/55
 ---
 
@@ -85,7 +85,7 @@ We will mandate that when a feature or bug fix is introduced under a feature
 flag, the CHANGELOG will include:
 
 - The suffix `(under feature flag)` in the title.
-- A `BREAKING CHANGES` paragraph will be added which describes the *new*
+- A `BREAKING CHANGES` paragraph will be added which describes the _new_
   behavior but disclaims that it will only apply to new projects created through
   `cdk init`. It will also indicate the context key this flag uses for users who
   wish to enable it manually in their project.
@@ -117,9 +117,10 @@ out which flag to enable in their `cdk.json` and how.
 This drawback will be mitigated by:
 
 - [ ] Adding a documentation section about feature flags in the developer guide,
-  pointing to the `cx-api/lib/features.ts` file as an index of feature flags.
-- [x] Announce the feature flag ID in our release notes under `BREAKING CHANGE:
-  (under feature flag)`.
+      pointing to the `cx-api/lib/features.ts` file as an index of feature
+      flags.
+- [x] Announce the feature flag ID in our release notes under
+      `BREAKING CHANGE: (under feature flag)`.
 
 ## Testing
 
@@ -148,7 +149,7 @@ enabled.
 To mitigate this risk we will:
 
 - [ ] Add feature flags to `cdk doctor` and update bug report template
-  accordingly to request users to run `cdk doctor`.
+      accordingly to request users to run `cdk doctor`.
 
 # Rationale and Alternatives
 
@@ -175,10 +176,10 @@ The contributor experience for using feature flags will be documented in the
 contribution guide and will involve the following steps:
 
 1. Seek the approval of a core team member that a feature flag can be used.
-   * If the feature in question is being planned via an RFC, and the feature
+   - If the feature in question is being planned via an RFC, and the feature
      flag is contained in the proposal, core team member approval should include
      the feature flag.
-   * If the feature is being tracked in a single issue without an RFC, approval
+   - If the feature is being tracked in a single issue without an RFC, approval
      should be indicated in this issue.
 2. Define a new const under
    [cx-api/lib/features.ts](https://github.com/aws/aws-cdk/blob/master/packages/%40aws-cdk/cx-api/lib/features.ts)
@@ -194,18 +195,18 @@ contribution guide and will involve the following steps:
 5. In your PR title (which goes into CHANGELOG), add a `(behind feature flag)`
    suffix. e.g:
 
-    ```
-    fix(core): impossible to use the same physical stack name for two stacks (under feature flag)
-    ```
+   ```
+   fix(core): impossible to use the same physical stack name for two stacks (under feature flag)
+   ```
 
-5. Under `BREAKING CHANGES`, add a prefix `(under feature flag)` and the name of
+6. Under `BREAKING CHANGES`, add a prefix `(under feature flag)` and the name of
    the flag in the postfix. For example:
 
-    ```
-    BREAKING CHANGE: (under feature flag) template file names for new projects created
-    through "cdk init" will use the template artifact ID instead of the physical stack
-    name to enable  multiple stacks to use the same name (feature flag: @aws-cdk/core:enableStackNameDuplicates)
-    ```
+   ```
+   BREAKING CHANGE: (under feature flag) template file names for new projects created
+   through "cdk init" will use the template artifact ID instead of the physical stack
+   name to enable  multiple stacks to use the same name (feature flag: @aws-cdk/core:enableStackNameDuplicates)
+   ```
 
 # Unresolved questions
 

--- a/text/0079-cdk-2.0.md
+++ b/text/0079-cdk-2.0.md
@@ -9,30 +9,38 @@ related issue: https://github.com/aws/aws-cdk-rfcs/issues/6
 
 # Summary
 
-This RFC details the strategy for building and releasing v2 of the AWS CDK, in addition to changes to tooling required
-to support this strategy. For details on the specific features themselves, refer to the corresponding RFCs.
+This RFC details the strategy for building and releasing v2 of the AWS CDK, in
+addition to changes to tooling required to support this strategy. For details on
+the specific features themselves, refer to the corresponding RFCs.
 
 # Motivation
 
-Since the CDK was announced as "generally available", the team has tried to limit breaking changes for users. However, a
-handful of features have emerged that the core team believes will make the CDK significantly simpler to use. These
-changes require a v2 release to signal to users that code changes may be required for adoption.
+Since the CDK was announced as "generally available", the team has tried to
+limit breaking changes for users. However, a handful of features have emerged
+that the core team believes will make the CDK significantly simpler to use.
+These changes require a v2 release to signal to users that code changes may be
+required for adoption.
 
-The main change of note is to consolidate all of the aws service construct libraries into a single package. The
-motivation for this change is detailed in [the corresponding RFC](https://github.com/aws/aws-cdk-rfcs/issues/6).
+The main change of note is to consolidate all of the aws service construct
+libraries into a single package. The motivation for this change is detailed in
+[the corresponding RFC](https://github.com/aws/aws-cdk-rfcs/issues/6).
 
-The core motivation of this proposal is to detail the plan required to release this change while continuing to support
-users referencing the v1 modules. In short, we want to make sure users have plenty of time to transition their code to
-using the new module structure and make that transition as easy as possible.
+The core motivation of this proposal is to detail the plan required to release
+this change while continuing to support users referencing the v1 modules. In
+short, we want to make sure users have plenty of time to transition their code
+to using the new module structure and make that transition as easy as possible.
 
 # Scope
 
-Since this is the first major version release since we announced General Availability of the AWS CDK, we will pay close
-attention to which changes are scoped in for this release. The main criteria used to determine whether a change is
-suitable for inclusion are:
+Since this is the first major version release since we announced General
+Availability of the AWS CDK, we will pay close attention to which changes are
+scoped in for this release. The main criteria used to determine whether a change
+is suitable for inclusion are:
 
-- the change _requires_ breaking existing customers of the changed API or feature
-  - a migration should be possible without incurring replacement of existing resources
+- the change _requires_ breaking existing customers of the changed API or
+  feature
+  - a migration should be possible without incurring replacement of existing
+    resources
 - the change addresses a well documented customer pain point
 - the change has had the due diligence done:
   - implications of the change are well documented
@@ -49,8 +57,8 @@ suitable for inclusion are:
   | ✅ In    | [RFC-6]     | Combine all AWS Construct Libraries into a single package                           |
   | ✅ In    | [RFC-192]   | Remove the _constructs compatibility layer_ in favor of using `constructs` directly |
 
-* The following changes were scoped out because a solution is likely to be achievable without breaking existing
-  customers:
+* The following changes were scoped out because a solution is likely to be
+  achievable without breaking existing customers:
 
   | Decision | RFC / Issue | Description                                                                |
   | -------- | ----------- | -------------------------------------------------------------------------- |
@@ -59,9 +67,10 @@ suitable for inclusion are:
   | 🚫 Out   | [RFC-193]   | Fix API for TypeScript type unions when used in statically typed languages |
   | 🚫 Out   | [#116]      | Easier identification of `@experimental` modules and APIs                  |
 
-* The following changes were scoped out because they can be achieved by introducing a new, fixed API, while deprecating
-  the current one. If done _before_ v2 is released, this effectively means `v2` will only retain the new and improved
-  API:
+* The following changes were scoped out because they can be achieved by
+  introducing a new, fixed API, while deprecating the current one. If done
+  _before_ v2 is released, this effectively means `v2` will only retain the new
+  and improved API:
 
   | Decision | RFC / Issue    | Description                                                                           |
   | -------- | -------------- | ------------------------------------------------------------------------------------- |
@@ -69,8 +78,9 @@ suitable for inclusion are:
   | 🚫 Out   | [aws-cdk#6966] | Decouple lambda's `AliasOptions` and `VersionOptions` from `EventInvokeConfigOptions` |
   | 🚫 Out   | _N/A_          | Remove support for Docker assets with parameters                                      |
 
-* The following changes were excluded because they would likely make migration of existing applications from v1 to v2
-  impossible, as they would likely lead to widespread replacement of existing resources (typically, because a new
+* The following changes were excluded because they would likely make migration
+  of existing applications from v1 to v2 impossible, as they would likely lead
+  to widespread replacement of existing resources (typically, because a new
   logical ID would be assigned to those):
 
   | Decision | RFC / Issue    | Description                                                           |
@@ -78,8 +88,8 @@ suitable for inclusion are:
   | 🚫 Out   | [aws-cdk#1687] | Un-mangle logical IDs generated for high-level (a.k.a. L2) constructs |
   | 🚫 Out   | [aws-cdk#6421] | Change logical ID attribution to avoid potential collisions           |
 
-* The following changes were excluded because the problem statement is too ambiguous or the solution not clear enough at
-  this point:
+* The following changes were excluded because the problem statement is too
+  ambiguous or the solution not clear enough at this point:
 
   | Decision | RFC / Issue    | Description                                                                   |
   | -------- | -------------- | ----------------------------------------------------------------------------- |
@@ -102,7 +112,8 @@ suitable for inclusion are:
 
 ## Overview
 
-The development and release of v2 will be done in several key steps, detailed in the following sections:
+The development and release of v2 will be done in several key steps, detailed in
+the following sections:
 
 1. [Preliminary work in v1](#preliminary-work-in-v1)
 1. [Create a v2 development branch by forking v1](#forking-v2-out-of-v1)
@@ -119,162 +130,210 @@ The development and release of v2 will be done in several key steps, detailed in
 
 ## Preliminary work in v1
 
-In order to minimize the divergence between the `v1` and `v2` codebases, all the work that can be performed directly in
-v1 will be front-loaded. This includes all work that can be prepared without breaking existing customers of CDK v1:
+In order to minimize the divergence between the `v1` and `v2` codebases, all the
+work that can be performed directly in v1 will be front-loaded. This includes
+all work that can be prepared without breaking existing customers of CDK v1:
 
-- Proactively deprecating APIs that need to be cleaned up in the v2 release, and introducing new replacement APIs (the
-  removal of deprecated memebers would thus leave only the new API in v2)
-- Work identified in [RFC-192] to be done directly in v1, ahead of the actual removal of the _constructs compatibility
-  layer_ in v2
+- Proactively deprecating APIs that need to be cleaned up in the v2 release, and
+  introducing new replacement APIs (the removal of deprecated memebers would
+  thus leave only the new API in v2)
+- Work identified in [RFC-192] to be done directly in v1, ahead of the actual
+  removal of the _constructs compatibility layer_ in v2
   - [Project board](https://github.com/aws/aws-cdk/projects/9)
-- Making the default state of _feature flags_ version-aware (i.e: the default is "off" in `v1`, and "on" in `v2`)
+- Making the default state of _feature flags_ version-aware (i.e: the default is
+  "off" in `v1`, and "on" in `v2`)
 
 ## Forking v2 out of v1
 
-The forking point will be achieved by cutting a new `v2` branch from the current tip of the `master` branch, where the
-following changes will be made right away:
+The forking point will be achieved by cutting a new `v2` branch from the current
+tip of the `master` branch, where the following changes will be made right away:
 
-1. the repository-wide `version` configuration will be updated to `2.0.0-alpha` (the pre-release identifier could be
-   different)
-1. all packages in the `@aws-cdk` scope included in the monolithic library bundle (see [Annex 1](#annex-1)) will be
-   marked `"private": true` in their respective `package.json` file
+1. the repository-wide `version` configuration will be updated to `2.0.0-alpha`
+   (the pre-release identifier could be different)
+1. all packages in the `@aws-cdk` scope included in the monolithic library
+   bundle (see [Annex 1](#annex-1)) will be marked `"private": true` in their
+   respective `package.json` file
 1. the `monocdk-experiment` package will be renamed to `aws-cdk-lib`
 
-A continuous integration pipeline will be configured on this new branch, so that pull requests can be automatically
-validated. Releases will be automatically published, however using the `next` NPM distribution tag instead of `latest`.
+A continuous integration pipeline will be configured on this new branch, so that
+pull requests can be automatically validated. Releases will be automatically
+published, however using the `next` NPM distribution tag instead of `latest`.
 
-> Other package managers we target (NuGet, Maven Central, PyPI) do not have a feature similar to NPM distribution tags.
-> In those, the version number is the only mechanism to signal pre-releases. To this effect, the version numbers used
-> must adhere to the correct local convension (which can be achieved using the existing version suffix features of
-> `jsii-pacmak`):
+> Other package managers we target (NuGet, Maven Central, PyPI) do not have a
+> feature similar to NPM distribution tags. In those, the version number is the
+> only mechanism to signal pre-releases. To this effect, the version numbers
+> used must adhere to the correct local convension (which can be achieved using
+> the existing version suffix features of `jsii-pacmak`):
 >
-> - **NuGet** [honors prerelease identifiers][nuget-versioning] in a way that is compatible with [Semantic Versioning].
->   Using the same version number as the NPM package will result in the correct behavior. The standard behavior of
->   `nuget` is to resolve to the _latest stable release_, while resolving to pre-releases requires the user to use a
->   pre-release identifier in their dependency specifications.
-> - **Maven Central** uses the `-SNAPSHOT` suffix to version numbers to denote versions that are in active development.
->   Publishing `SNAPSHOT` involves using a `SNAPSHOT`-specific repository. _Maven Central_ offers a _SNAPSHOT_
->   repository (at `https://oss.sonatype.org/content/repositories/snapshots`), which can be used. In order to install
->   `SNAPSHOT` releases, customers must manually enable the `SNAPSHOT` repository in their configuration.
-> - **PyPI** uses a specific set of version suffixes to identify pre-releases (`.dev#` for development releases, `.a#`
->   for alphas, `.b#` for betas, and `.rc#` for release candidates). Modern package installers ignore pre-releases by
->   default.
+> - **NuGet** [honors prerelease identifiers][nuget-versioning] in a way that is
+>   compatible with [Semantic Versioning]. Using the same version number as the
+>   NPM package will result in the correct behavior. The standard behavior of
+>   `nuget` is to resolve to the _latest stable release_, while resolving to
+>   pre-releases requires the user to use a pre-release identifier in their
+>   dependency specifications.
+> - **Maven Central** uses the `-SNAPSHOT` suffix to version numbers to denote
+>   versions that are in active development. Publishing `SNAPSHOT` involves
+>   using a `SNAPSHOT`-specific repository. _Maven Central_ offers a _SNAPSHOT_
+>   repository (at `https://oss.sonatype.org/content/repositories/snapshots`),
+>   which can be used. In order to install `SNAPSHOT` releases, customers must
+>   manually enable the `SNAPSHOT` repository in their configuration.
+> - **PyPI** uses a specific set of version suffixes to identify pre-releases
+>   (`.dev#` for development releases, `.a#` for alphas, `.b#` for betas, and
+>   `.rc#` for release candidates). Modern package installers ignore
+>   pre-releases by default.
 >
-> For **NuGet** and **Maven Central**, the [GitHub Packages] registry could be used as an alternate or additional
-> location where customers would consume pre-releases from.
+> For **NuGet** and **Maven Central**, the [GitHub Packages] registry could be
+> used as an alternate or additional location where customers would consume
+> pre-releases from.
 
 [semantic versioning]: https://semver.org
-[nuget-versioning]: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#pre-release-versions
+[nuget-versioning]:
+  https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#pre-release-versions
 [github packages]: https://github.com/features/packages
 
-As long as the codebases have not diverged too much, it should be possible to continue forward-porting new developments
-on top of the `v2` branch by simply cherry-picking new commits from the `master` branch. Alternatively, it might be
-possible to simply periodically merge `master` into `v2`. This task can easily be automated.
+As long as the codebases have not diverged too much, it should be possible to
+continue forward-porting new developments on top of the `v2` branch by simply
+cherry-picking new commits from the `master` branch. Alternatively, it might be
+possible to simply periodically merge `master` into `v2`. This task can easily
+be automated.
 
-A new standard operating procedure (SOP / MCM) will be made to support manually releasing a CDK `v2` release until this
-process is fully automated. Additionally, canaries and integration tests need to be prepared to ensure the ongoing
-quality of the `v2` release stream.
+A new standard operating procedure (SOP / MCM) will be made to support manually
+releasing a CDK `v2` release until this process is fully automated.
+Additionally, canaries and integration tests need to be prepared to ensure the
+ongoing quality of the `v2` release stream.
 
-As the codebases grow further appart, manual work may be required in order to forward-port feature work merged in
-`master`. As a consequence we will strive to keep divergences to a minimum for as long as possible. The on-call engineer
-will be tasked with reviewing and merging automated pull requests created twice a week (e.g: on _Mondays_ and
-_Thursdays_), manually resolving merge conflicts as needed.
+As the codebases grow further appart, manual work may be required in order to
+forward-port feature work merged in `master`. As a consequence we will strive to
+keep divergences to a minimum for as long as possible. The on-call engineer will
+be tasked with reviewing and merging automated pull requests created twice a
+week (e.g: on _Mondays_ and _Thursdays_), manually resolving merge conflicts as
+needed.
 
 ## Monolithic Packaging
 
-The AWS Construct Library will be released as a single artifact, instead of a collection of more than 100 libraries. The
-`monocdk-experiment` package has the tools necessary to re-package the existing _hypermodular_ libraries into a single
-packaging. Re-using that same process will allow keeping the difference between `master` and `v2` as constrained as
-possible (reducing the need for manual intervention in forward-porting features). No additional packaging work is needed
-once the `v2` branch has been forked from `master`, as the renaming of `monocdk-experiment` to `aws-cdk-lib` and
-marking all bundled packages `private` is taken care of at that time.
+The AWS Construct Library will be released as a single artifact, instead of a
+collection of more than 100 libraries. The `monocdk-experiment` package has the
+tools necessary to re-package the existing _hypermodular_ libraries into a
+single packaging. Re-using that same process will allow keeping the difference
+between `master` and `v2` as constrained as possible (reducing the need for
+manual intervention in forward-porting features). No additional packaging work
+is needed once the `v2` branch has been forked from `master`, as the renaming of
+`monocdk-experiment` to `aws-cdk-lib` and marking all bundled packages `private`
+is taken care of at that time.
 
-However, since users will all use a single `aws-cdk-lib` library, the granularity of information collected via the
-`AWS::CDK::Metadata` resource (injected by the [version reporting] feature) will be significantly reduced. In order to
-retain ability to provide a signal to customers affected by a security or reliability issue (and not to _all_ customers
-using the CDK), the mechanism will need to be updated to enable identifying specific subsets of the construct library.
-While the exact design of this change is subject to change, one approach is to generate additional code in the
-_CloudFormation Resources_ so they self-report usage, allowing the `AWS::CDK::Metadata` to include data as specific as
-the resource types being used when synthesizing a stack. The collected data will remain completely transparent and
-auditable by users, who will naturally retain the ability to opt out of this feature.
+However, since users will all use a single `aws-cdk-lib` library, the
+granularity of information collected via the `AWS::CDK::Metadata` resource
+(injected by the [version reporting] feature) will be significantly reduced. In
+order to retain ability to provide a signal to customers affected by a security
+or reliability issue (and not to _all_ customers using the CDK), the mechanism
+will need to be updated to enable identifying specific subsets of the construct
+library. While the exact design of this change is subject to change, one
+approach is to generate additional code in the _CloudFormation Resources_ so
+they self-report usage, allowing the `AWS::CDK::Metadata` to include data as
+specific as the resource types being used when synthesizing a stack. The
+collected data will remain completely transparent and auditable by users, who
+will naturally retain the ability to opt out of this feature.
 
-[version reporting]: https://docs.aws.amazon.com/cdk/latest/guide/cli.html#version_reporting
+[version reporting]:
+  https://docs.aws.amazon.com/cdk/latest/guide/cli.html#version_reporting
 
 ## Feature Implementation
 
-This section provides detailed plans for implementing the features that were scoped in for this new major version.
+This section provides detailed plans for implementing the features that were
+scoped in for this new major version.
 
 ### Removal of `@deprecated` APIs
 
-The definition of `@deprecated` in the CDK specifies that annotated APIs will be removed in the next major version
-release. Consequently, we will systematically remove all `@deprecated` APIs from the codebase upon cutting a new major
+The definition of `@deprecated` in the CDK specifies that annotated APIs will be
+removed in the next major version release. Consequently, we will systematically
+remove all `@deprecated` APIs from the codebase upon cutting a new major
 version.
 
-*Sidenote:* There are a few APIs in the CDK that don't follow the above definition, specifically, [lambda runtimes] and
-[RDS Oracle versions]. The APIs in these cases are marked deprecated because it has either been deprecated by the
-underlying AWS service or the AWS service has deemed it to have fallen out of best practice. In such cases, either
-these APIs will be removed in CDKv2, or if deemed necessary, `@deprecated` annotation will be removed and replaced by
+_Sidenote:_ There are a few APIs in the CDK that don't follow the above
+definition, specifically, [lambda runtimes] and [RDS Oracle versions]. The APIs
+in these cases are marked deprecated because it has either been deprecated by
+the underlying AWS service or the AWS service has deemed it to have fallen out
+of best practice. In such cases, either these APIs will be removed in CDKv2, or
+if deemed necessary, `@deprecated` annotation will be removed and replaced by
 'DEPRECATED:' note in its documentation.
 
-As described above in the [forking v2 out of v1](#forking-v2-out-of-v1) section, there will be a significant period of
-time when both CDKv1 and CDKv2 will be in active development. During this time, they will be tracked in the source
-code respectively by two active branches, `master` and `v2`, where changes on `master` will be forward merged onto `v2`.
-Removing the deprecated APIs by hand right at the beginning is going to result in increased maintenance overhead caused
-by merge conflicts. See [alternatives section](#removal-of-deprecated-apis---why-not-remove-these-by-hand) for more
-details.
+As described above in the [forking v2 out of v1](#forking-v2-out-of-v1) section,
+there will be a significant period of time when both CDKv1 and CDKv2 will be in
+active development. During this time, they will be tracked in the source code
+respectively by two active branches, `master` and `v2`, where changes on
+`master` will be forward merged onto `v2`. Removing the deprecated APIs by hand
+right at the beginning is going to result in increased maintenance overhead
+caused by merge conflicts. See
+[alternatives section](#removal-of-deprecated-apis---why-not-remove-these-by-hand)
+for more details.
 
-The following strategy will be used to reduce merge conflicts while shipping CDKv2 without deprecated APIs right from
-its first release -
+The following strategy will be used to reduce merge conflicts while shipping
+CDKv2 without deprecated APIs right from its first release -
 
 Before creating the `v2` branch,
 
-- The `jsii` assembler will be updated to accept a `--no-deprecated` flag that will strip out all deprecated methods,
-properties, classes and interfaces. This will be achieved via a typescript transform that is run before assembly
-generation. A proof of concept for this transform is available [here](https://github.com/nija-at/cdk-deprecated-api-poc).
+- The `jsii` assembler will be updated to accept a `--no-deprecated` flag that
+  will strip out all deprecated methods, properties, classes and interfaces.
+  This will be achieved via a typescript transform that is run before assembly
+  generation. A proof of concept for this transform is available
+  [here](https://github.com/nija-at/cdk-deprecated-api-poc).
 
-- `cdk-build` will be updated to recognize the environment variable `CDK_BLOCK_DEPRECATIONS` and set the
-`--no-deprecated` flag on the `jsii` assembler.
+- `cdk-build` will be updated to recognize the environment variable
+  `CDK_BLOCK_DEPRECATIONS` and set the `--no-deprecated` flag on the `jsii`
+  assembler.
 
-- All current usage of deprecated APIs within the CDK repository will be removed. In addition, a new check will be
-added to pull requests on the `master` branch, that will run a full CDK build **and test** with the
-`CDK_BLOCK_DEPRECATIONS` environment variable set. The typescript compilation and execution of the CDK's comprehensive
-unit test suite should highlight any usage of deprecated APIs.
+- All current usage of deprecated APIs within the CDK repository will be
+  removed. In addition, a new check will be added to pull requests on the
+  `master` branch, that will run a full CDK build **and test** with the
+  `CDK_BLOCK_DEPRECATIONS` environment variable set. The typescript compilation
+  and execution of the CDK's comprehensive unit test suite should highlight any
+  usage of deprecated APIs.
 
-- In order to support unit tests that verify the behaviour of deprecated APIs, `cdk-test` will be updated to recognize
-a new pragma `!/// !cdk-test:allow-deprecations` and the `CDK_BLOCK_DEPRECATIONS` environment variable. Tests holding
-this pragma will be skipped when `CDK_BLOCK_DEPRECATIONS` is set.
+- In order to support unit tests that verify the behaviour of deprecated APIs,
+  `cdk-test` will be updated to recognize a new pragma
+  `!/// !cdk-test:allow-deprecations` and the `CDK_BLOCK_DEPRECATIONS`
+  environment variable. Tests holding this pragma will be skipped when
+  `CDK_BLOCK_DEPRECATIONS` is set.
 
 For the first and every subsequent release of CDKv2,
 
-- the release pipeline will be configured with the `CDK_BLOCK_DEPRECATIONS` environment variable that will run the
-previously mentioned typescript transform as part of monolithic packaging (i.e., generation of `aws-cdk-lib`).
+- the release pipeline will be configured with the `CDK_BLOCK_DEPRECATIONS`
+  environment variable that will run the previously mentioned typescript
+  transform as part of monolithic packaging (i.e., generation of `aws-cdk-lib`).
 
-The `master` branch will remain in this state until we are ready to flip `v2` branch to be the new
-`master`. At this point,
+The `master` branch will remain in this state until we are ready to flip `v2`
+branch to be the new `master`. At this point,
 
-- a two day code freeze will be instituted and a one time clean up of all deprecated APIs from the source
-code will be performed.
+- a two day code freeze will be instituted and a one time clean up of all
+  deprecated APIs from the source code will be performed.
 
-- The PR check will be removed from the `master` branch. Let the deprecations on CDKv2 begin!
+- The PR check will be removed from the `master` branch. Let the deprecations on
+  CDKv2 begin!
 
-[import rewrites]: https://github.com/aws/aws-cdk/tree/master/packages/%40monocdk-experiment/rewrite-imports
-[lambda runtimes]: https://github.com/aws/aws-cdk/blob/b757d8856216152b03c1ed3ffe2f29719aff8c27/packages/%40aws-cdk/aws-lambda/lib/runtime.ts#L37-L63
-[RDS Oracle versions]: https://github.com/aws/aws-cdk/blob/34f40b9fb4b467c9c7af290400efa2c8ac8c8e10/packages/%40aws-cdk/aws-rds/lib/cluster-engine.ts#L449-L471
+[import rewrites]:
+  https://github.com/aws/aws-cdk/tree/master/packages/%40monocdk-experiment/rewrite-imports
+[lambda runtimes]:
+  https://github.com/aws/aws-cdk/blob/b757d8856216152b03c1ed3ffe2f29719aff8c27/packages/%40aws-cdk/aws-lambda/lib/runtime.ts#L37-L63
+[rds oracle versions]:
+  https://github.com/aws/aws-cdk/blob/34f40b9fb4b467c9c7af290400efa2c8ac8c8e10/packages/%40aws-cdk/aws-rds/lib/cluster-engine.ts#L449-L471
 
 ### Resetting v1 feature flags
 
-When developing new behaviors that are incompatible with previous ones, feature flags were introduced to allow customers
-control of when they migrate over to the _new behavior_. However, when a new major version release is issued, the _new
-behavior_ ideally becomes the _only behavior_.
+When developing new behaviors that are incompatible with previous ones, feature
+flags were introduced to allow customers control of when they migrate over to
+the _new behavior_. However, when a new major version release is issued, the
+_new behavior_ ideally becomes the _only behavior_.
 
-In certain cases, users may be unable to migrate over to the _new behavior_ of a feature flag without incurring
-replacement of resources. Removing ability to toggle the feature off in a new major version would significantly
-complicate upgrading applications to the new major version. Feature flags will be critically evaluated, and in cases
-where a migration is impossible or difficult, the default state will be changed from disabled to enabled, but users will
+In certain cases, users may be unable to migrate over to the _new behavior_ of a
+feature flag without incurring replacement of resources. Removing ability to
+toggle the feature off in a new major version would significantly complicate
+upgrading applications to the new major version. Feature flags will be
+critically evaluated, and in cases where a migration is impossible or difficult,
+the default state will be changed from disabled to enabled, but users will
 retain the ability to disable as needed.
 
-> Here is a table summarizing existing feature flags, the migration process, and whether they should be removed or only
-> have thier default behavior toggled:
+> Here is a table summarizing existing feature flags, the migration process, and
+> whether they should be removed or only have thier default behavior toggled:
 >
 > | Feature Flag                              | Migration                                            | Decision  |
 > | ----------------------------------------- | ---------------------------------------------------- | --------- |
@@ -282,81 +341,102 @@ retain the ability to disable as needed.
 > | `@aws-cdk/core:enableStackNameDuplicates` | Update to new file names under `cdk.out`             | 🚮 Remove |
 > | `@aws-cdk/core:newStyleStackSynthesis`    | Re-bootstrap environments                            | 🚮 Remove |
 
-In order to reduce the codebase divergence between `master` and `v2` (in order to minimize the amount of manual work
-involved in forward-porting features on `v2`), existing feature flags must be made version-aware, such that they are
-enabled by default (and impossible to disable if a clean and reasonably simple migration is possible) when the current
-version is greater then `2.0.0-0`.
+In order to reduce the codebase divergence between `master` and `v2` (in order
+to minimize the amount of manual work involved in forward-porting features on
+`v2`), existing feature flags must be made version-aware, such that they are
+enabled by default (and impossible to disable if a clean and reasonably simple
+migration is possible) when the current version is greater then `2.0.0-0`.
 
-The actual removal of code paths that support the _old behavior_ of feature flags that can no longer be disabled will be
-deferred to _after_ the new major version has reached _General Availability_.
+The actual removal of code paths that support the _old behavior_ of feature
+flags that can no longer be disabled will be deferred to _after_ the new major
+version has reached _General Availability_.
 
 ## Documentation Updates
 
-Before formally announcing the availability of CDK v2 for early adopters, a documentation source must be availbable to
-facilitate use of the new repository. The minimum bar should be availability of an API reference documentation for the
+Before formally announcing the availability of CDK v2 for early adopters, a
+documentation source must be availbable to facilitate use of the new repository.
+The minimum bar should be availability of an API reference documentation for the
 v2 codebase that is usable. This entails the following items:
 
-- Both documentations for `v1` and `v2` must be browseable on the [AWS CDK Reference Documentation] site
-- The `v2` documentation site must render the `README.md` document for all _submodules_ together with the API
-  documentation, with a presentation that is similar to that of `v1` (so migrating users do not have to learn a
-  completely new reference documentation layout)
+- Both documentations for `v1` and `v2` must be browseable on the [AWS CDK
+  Reference Documentation] site
+- The `v2` documentation site must render the `README.md` document for all
+  _submodules_ together with the API documentation, with a presentation that is
+  similar to that of `v1` (so migrating users do not have to learn a completely
+  new reference documentation layout)
 
-At the same time, the work to update the [AWS CDK User Guide] should be scoped and planned out. The updates to the User
-Guide must also include a migration guide to help developers move from CDK v1 over to v2. Special attention will be
-spent in ensuring the v2 release notes contain a clear and accurate summary of breaking changes and how users should
-update their applications.
+At the same time, the work to update the [AWS CDK User Guide] should be scoped
+and planned out. The updates to the User Guide must also include a migration
+guide to help developers move from CDK v1 over to v2. Special attention will be
+spent in ensuring the v2 release notes contain a clear and accurate summary of
+breaking changes and how users should update their applications.
 
 [aws cdk reference documentation]: https://docs.aws.amazon.com/cdk/api/latest/
 [aws cdk user guide]: https://docs.aws.amazon.com/cdk/latest/guide/home.html
 
 ## Prerelease Announcement
 
-Once sufficient documentation is in place, and the framework-level changes have been implemented and integration tested,
-we will be able to start promoting the upcoming new release and point early adopters to experimental builds of CDK v2.
+Once sufficient documentation is in place, and the framework-level changes have
+been implemented and integration tested, we will be able to start promoting the
+upcoming new release and point early adopters to experimental builds of CDK v2.
 This will allow gathering early feedback on the updated experience.
 
-A prerelease announcement will be published, formally announcing our plan to release AWS CDK v2 in the near future. This
-prerelease announcement should at least mention the following elements:
+A prerelease announcement will be published, formally announcing our plan to
+release AWS CDK v2 in the near future. This prerelease announcement should at
+least mention the following elements:
 
-- A provisional list of breaking changes expected to be made to the _AWS Construct Library_ (`aws-cdk-lib`) APIs during
-  the [Construct Library Maintenance Tasks](#construct-library-maintenance-tasks) phase
-- A finalized proposal for the CDK [v1 maintenance plan](#aws-cdk-maintenance-policy), and a call for developers to
-  provide feedback on that
-- A minimal migration guide for bravehearts who are inclined to try and migrate their existing (**non-production**)
-  applications
+- A provisional list of breaking changes expected to be made to the _AWS
+  Construct Library_ (`aws-cdk-lib`) APIs during the
+  [Construct Library Maintenance Tasks](#construct-library-maintenance-tasks)
+  phase
+- A finalized proposal for the CDK
+  [v1 maintenance plan](#aws-cdk-maintenance-policy), and a call for developers
+  to provide feedback on that
+- A minimal migration guide for bravehearts who are inclined to try and migrate
+  their existing (**non-production**) applications
 
 ## Construct Library Maintenance Tasks
 
-All breaking changes should be handled in the form of a deprecation in CDK v1. In the event a particular change cannot
-be achieved in this way, a limited amount of time will be provided when _AWS Construct Library_ owners (as well as third
-party contributors) will be allowed to introduce API-breaking changes in the `v2` branch. These should be limited to
-items that were identified and documented as part of the [Prerelease Announcement](#prerelease-announcement). Additional
-changes can however be introduced if a well documented proposal achieves consensus among the core development team. All
-breaking changes (including those planned in the prerelease announcement) will be documented in the release notes for
-each subsequent prerelease version, per the standard process.
+All breaking changes should be handled in the form of a deprecation in CDK v1.
+In the event a particular change cannot be achieved in this way, a limited
+amount of time will be provided when _AWS Construct Library_ owners (as well as
+third party contributors) will be allowed to introduce API-breaking changes in
+the `v2` branch. These should be limited to items that were identified and
+documented as part of the [Prerelease Announcement](#prerelease-announcement).
+Additional changes can however be introduced if a well documented proposal
+achieves consensus among the core development team. All breaking changes
+(including those planned in the prerelease announcement) will be documented in
+the release notes for each subsequent prerelease version, per the standard
+process.
 
 ## Developer Preview
 
-At the end of the [Construct Library Maintenance Tasks](#construct-library-maintenance-tasks) window, a moratorium on
-breaking changes in v2 will be declared, as the codebase is thoroughly tested and vetted. At the end of the vetting
-period, and once known issues have been addressed, CDK v2 can be declared _Developer Preview_.
+At the end of the
+[Construct Library Maintenance Tasks](#construct-library-maintenance-tasks)
+window, a moratorium on breaking changes in v2 will be declared, as the codebase
+is thoroughly tested and vetted. At the end of the vetting period, and once
+known issues have been addressed, CDK v2 can be declared _Developer Preview_.
 
-Once the _Developer Preview_ has been declared, breaking changes will only be allowed if they are motivated by
-overwhelming customer feedback or the absence of alternate solutions to fix a well-documented pain point introduced by
-v2 changes.
+Once the _Developer Preview_ has been declared, breaking changes will only be
+allowed if they are motivated by overwhelming customer feedback or the absence
+of alternate solutions to fix a well-documented pain point introduced by v2
+changes.
 
 ## Feedback Phase
 
-During _Developer Preview_, we will keep listening to customer feedback and address bugs as they are discovered. The CDK
-[version reporting] dataset will be used to track adoption of the new version. We will encourage customers to provide
-feedback on the upcoming new release using a pinned GitHub issue, and possibly other means.
+During _Developer Preview_, we will keep listening to customer feedback and
+address bugs as they are discovered. The CDK [version reporting] dataset will be
+used to track adoption of the new version. We will encourage customers to
+provide feedback on the upcoming new release using a pinned GitHub issue, and
+possibly other means.
 
 [version reporting]: https://docs.aws.amazon.com/cdk/latest/guide/tools.html
 
 ## General Availability
 
-After the _Developer Preview_ has been sufficiently vetted, a timeline for _General Availability_ will be agreed upon by
-maintainers. The _General Availability_ checkist includes the following items:
+After the _Developer Preview_ has been sufficiently vetted, a timeline for
+_General Availability_ will be agreed upon by maintainers. The _General
+Availability_ checkist includes the following items:
 
 - [ ] Documentation
   - [ ] API Reference Documentation
@@ -368,7 +448,8 @@ maintainers. The _General Availability_ checkist includes the following items:
   - [ ] Examples built and tested against v2
 - [ ] No v1 feature is missing from v2 (unless it was deprecated in v1)
 
-Once the criteria have been satisfied, the high-level procedure for officially releasing CDK v2 is:
+Once the criteria have been satisfied, the high-level procedure for officially
+releasing CDK v2 is:
 
 1. Create a new `v1` branch from the `master` branch
    1. Configure GitHub branch protection on `v1` as appropriate
@@ -377,75 +458,99 @@ Once the criteria have been satisfied, the high-level procedure for officially r
    1. Force-push `v2` on `master`
    1. Delete `v2` and all related CI/CD infrastructure
 1. Perform a _normal_ release
-1. Ceremoniously annouce CDK v2 is _Generally Available_, and repeat the v1 maintenance plan
+1. Ceremoniously annouce CDK v2 is _Generally Available_, and repeat the v1
+   maintenance plan
 
 ## Clean Up
 
-Now that the new major version has been declared _Generally Available_, the previous major (`v1`) has entered
-_maintenance_ mode. Forward porting is no longer exercised: instead, bug fixes on `master` will be back-ported to `v1`
-when necessary. This means `master` can diverge more significantly from `v1` than in earler stages of the process.
+Now that the new major version has been declared _Generally Available_, the
+previous major (`v1`) has entered _maintenance_ mode. Forward porting is no
+longer exercised: instead, bug fixes on `master` will be back-ported to `v1`
+when necessary. This means `master` can diverge more significantly from `v1`
+than in earler stages of the process.
 
-The definition of `v1` feature flags and the code paths supporthing the _old behavior_ of those can be deleted (they
-were previously simply _neutralized_ in `v2` so that they could no longer be disabled there).
+The definition of `v1` feature flags and the code paths supporthing the _old
+behavior_ of those can be deleted (they were previously simply _neutralized_ in
+`v2` so that they could no longer be disabled there).
 
 ## Monitoring Adoption
 
-We will keep an eye on adoption of CDK v2 thanks to the [version reporting] dataset. Should adoption pick up too slowly,
-actions will be taken to understand the causes for slow adoption and identify opportunities to provide additional
+We will keep an eye on adoption of CDK v2 thanks to the [version reporting]
+dataset. Should adoption pick up too slowly, actions will be taken to understand
+the causes for slow adoption and identify opportunities to provide additional
 tooling to remove roadblocks and facilitate migration.
 
 [version reporting]: https://docs.aws.amazon.com/cdk/latest/guide/tools.html
 
 ## Deprecation of v1
 
-Based on the [maintenance policy](#aws-cdk-maintenance-policy), new feature development is to stop on CDK v1, and only
-critical bugs and security issues will be addressed in the `v1` release line.
+Based on the [maintenance policy](#aws-cdk-maintenance-policy), new feature
+development is to stop on CDK v1, and only critical bugs and security issues
+will be addressed in the `v1` release line.
 
-New GitHub labels will be added to differentiate bugs reported against `v1` from those reported against `v2`. Bugs
-reported against `v1` will be closed with a standard message during triaging unless they are identified as critical or
+New GitHub labels will be added to differentiate bugs reported against `v1` from
+those reported against `v2`. Bugs reported against `v1` will be closed with a
+standard message during triaging unless they are identified as critical or
 security-impacting (meaning they qualify for `P0` handling).
 
-A similar provision applies to pull-requests, as they will only be accepted in the `v1` branch if they are non-breaking
-and fall into one of the following categories:
+A similar provision applies to pull-requests, as they will only be accepted in
+the `v1` branch if they are non-breaking and fall into one of the following
+categories:
 
 - features dedicated to facilitating migration from `v1` to `v2`
-  - e.g: outputting synth-time warnings when @deprecated APIs are used to facilitate discovery
+  - e.g: outputting synth-time warnings when @deprecated APIs are used to
+    facilitate discovery
 - features back-ported from `v2`
-- bug fixes (where relevant, the author is expected to submit the `v2` fix at the same time)
+- bug fixes (where relevant, the author is expected to submit the `v2` fix at
+  the same time)
 
-Community pull requests against the `v1` branch may be processed with lower priority than those against `v2`, as the
-community is encouraged to shift their efforts towards the latest major version.
+Community pull requests against the `v1` branch may be processed with lower
+priority than those against `v2`, as the community is encouraged to shift their
+efforts towards the latest major version.
 
 # AWS CDK Maintenance Policy
 
-Customers of the CDK must be able to rely on the perenity of major version releases. On the other hand, maintaining
-multiple major versions at the same time can be challenging, especially if feature work is expected ot happen on both
-branches. Our goal is to minimize the cost of maintaining multiple major versions at the same time, while enabling
-customers to migrate to a new major version release at their own pace.
+Customers of the CDK must be able to rely on the perenity of major version
+releases. On the other hand, maintaining multiple major versions at the same
+time can be challenging, especially if feature work is expected ot happen on
+both branches. Our goal is to minimize the cost of maintaining multiple major
+versions at the same time, while enabling customers to migrate to a new major
+version release at their own pace.
 
-To this effect, we define the following life-cycle stages for libraries and tools (later on referenced generically as
-_software_) that are part of the CDK ecosystem:
+To this effect, we define the following life-cycle stages for libraries and
+tools (later on referenced generically as _software_) that are part of the CDK
+ecosystem:
 
-- **Developer Preview**: During this phase, software is not supported, should not be used in production environments,
-  and are meant for early access and feedback purposes only. It is possible for future releases to introduce breaking
-  changes. Once AWS identifies a release to be a stable product, it may mark it as a _Release Candidate_. _Release
-  Candidates_ are ready for _General Availability_ unless significant bugs emerge, and will receive full AWS support.
-- **Full Support**: During this phase, software is fully supported. AWS will provide regular releases that include new
-  features, support for new services, API updates for existing services, as well as bug and security fixes.
-- **Maintenance Announcement**: AWS will make a public announcement at least 6 months before software enters the
-  **Maintenance** phase. During this period, software will continue to be fully supported. Typically, this announcement
+- **Developer Preview**: During this phase, software is not supported, should
+  not be used in production environments, and are meant for early access and
+  feedback purposes only. It is possible for future releases to introduce
+  breaking changes. Once AWS identifies a release to be a stable product, it may
+  mark it as a _Release Candidate_. _Release Candidates_ are ready for _General
+  Availability_ unless significant bugs emerge, and will receive full AWS
+  support.
+- **Full Support**: During this phase, software is fully supported. AWS will
+  provide regular releases that include new features, support for new services,
+  API updates for existing services, as well as bug and security fixes.
+- **Maintenance Announcement**: AWS will make a public announcement at least 6
+  months before software enters the **Maintenance** phase. During this period,
+  software will continue to be fully supported. Typically, this announcement
   happens at the same time as the next major version is introduced.
-- **Maintenance**: During this phase, AWS limits releases to address critical bug fixes and security issues only.
-  Software will no longer receive API updates for new or existing services, or be updated to support new regions. The
-  **Maintenance** phase has a default duration of 12 months, unless otherwise specified as part of the **Maintenance
-  Announcement**.
-- **End-of-Support**: This phase starts at the scheduled end of the **Maintenance** phase. Software that has reached
-  **End-of-Support** will no longer receive updates or new releases. Previously published releases will continue to be
-  available via public package managers and the code will remain accessible on GitHub. The GitHub repository may be
-  archived. Use of software that has reached **End-of-Support** is done at the user's discretion. We recommend users
-  upgrade to the latest major version (the release in **Full Support** phase).
+- **Maintenance**: During this phase, AWS limits releases to address critical
+  bug fixes and security issues only. Software will no longer receive API
+  updates for new or existing services, or be updated to support new regions.
+  The **Maintenance** phase has a default duration of 12 months, unless
+  otherwise specified as part of the **Maintenance Announcement**.
+- **End-of-Support**: This phase starts at the scheduled end of the
+  **Maintenance** phase. Software that has reached **End-of-Support** will no
+  longer receive updates or new releases. Previously published releases will
+  continue to be available via public package managers and the code will remain
+  accessible on GitHub. The GitHub repository may be archived. Use of software
+  that has reached **End-of-Support** is done at the user's discretion. We
+  recommend users upgrade to the latest major version (the release in **Full
+  Support** phase).
 
-Here is a visual illystration of the major version life-cycle (timelines are purely illustrative):
+Here is a visual illystration of the major version life-cycle (timelines are
+purely illustrative):
 
 ![Illustration of the Maintenance Policy](../images/MaintenancePolicy.png)
 
@@ -453,113 +558,147 @@ Here is a visual illystration of the major version life-cycle (timelines are pur
 
 ## Rationale
 
-The main motivation for moving forward with a v2 release now is the desire to start moving towards the single module
-structure. The current multi module structure is known to cause a lot of confusion for users. For more details on why
-aws-cdk is moving to a single package, see the [MonoCDK RFC](https://github.com/aws/aws-cdk-rfcs/issues/6).
+The main motivation for moving forward with a v2 release now is the desire to
+start moving towards the single module structure. The current multi module
+structure is known to cause a lot of confusion for users. For more details on
+why aws-cdk is moving to a single package, see the
+[MonoCDK RFC](https://github.com/aws/aws-cdk-rfcs/issues/6).
 
-This belief that releasing a single package will make user's lives easier is countered by a strong desire to limit the
-exposure of users to breaking changes. Though the aws-cdk is relatively young, one of the core tenants of the project is
-stability. Major version upgrades are an important part of building and maintaining libraries. However, limiting the
-cost of breaking changes included in major releases is important. It isn't in the interest of the project to drop a new
-major version, immediately stop supporting the previous version, and leave the onus on the user to "catch up".
+This belief that releasing a single package will make user's lives easier is
+countered by a strong desire to limit the exposure of users to breaking changes.
+Though the aws-cdk is relatively young, one of the core tenants of the project
+is stability. Major version upgrades are an important part of building and
+maintaining libraries. However, limiting the cost of breaking changes included
+in major releases is important. It isn't in the interest of the project to drop
+a new major version, immediately stop supporting the previous version, and leave
+the onus on the user to "catch up".
 
-Therefore, a major part of the motivation to perform this work is to establish a framework for releasing new major
-versions of the cdk in a controlled and standardized way. Establishing standards and tools to automatically handle
-deprecations, feature flag resets, and pre-release versioning will allow the core team and contributors to leverage
-these to better control breakage. The path to introduce a breaking change is then a lot more clear.
+Therefore, a major part of the motivation to perform this work is to establish a
+framework for releasing new major versions of the cdk in a controlled and
+standardized way. Establishing standards and tools to automatically handle
+deprecations, feature flag resets, and pre-release versioning will allow the
+core team and contributors to leverage these to better control breakage. The
+path to introduce a breaking change is then a lot more clear.
 
-First we ask, "can this be implemented behind a feature flag"? If so, that's usually the answer. Build tooling tells us
-when feature flags can be removed and warns users when it has happened. Migration path to new behavior has to be
-considered and should be documented clearly at the time the flag is created. This goes in the migration guide of the
-next major version.
+First we ask, "can this be implemented behind a feature flag"? If so, that's
+usually the answer. Build tooling tells us when feature flags can be removed and
+warns users when it has happened. Migration path to new behavior has to be
+considered and should be documented clearly at the time the flag is created.
+This goes in the migration guide of the next major version.
 
-If it can't be implemented behind a feature flag, we ask "can a new code path be defined and the old one deprecated?".
-Once again, migration path is considered and documented and it goes into the next major version migration guide.
+If it can't be implemented behind a feature flag, we ask "can a new code path be
+defined and the old one deprecated?". Once again, migration path is considered
+and documented and it goes into the next major version migration guide.
 
-If the migration path is too painful in either situation, can it be reduced somehow? Can it be automated? etc...
+If the migration path is too painful in either situation, can it be reduced
+somehow? Can it be automated? etc...
 
-The desire to move forward with the change in packaging strategy has brought the need for these tools and procedures to
-the forefront.
+The desire to move forward with the change in packaging strategy has brought the
+need for these tools and procedures to the forefront.
 
 ## Alternatives
 
-The most notable alternative to releasing a new major version, is basically to not. This could be done a couple of ways.
+The most notable alternative to releasing a new major version, is basically to
+not. This could be done a couple of ways.
 
-The first is not moving forward with the packaging change at all. For the argument against that, see the
+The first is not moving forward with the packaging change at all. For the
+argument against that, see the
 [MonoCDK RFC](https://github.com/aws/aws-cdk-rfcs/issues/6).
 
-The second is to simply release the new module, `aws-cdk-lib` locked to the same `1.x.x` version that the other modules
-are currently locked to. In fact, that is the first stage of the release process, its just under the name
-`monocdk-experiment`. This was a low cost way for the dev team, contributors, and users to experiment with the new
-structure before investing too much towards it.
+The second is to simply release the new module, `aws-cdk-lib` locked to the same
+`1.x.x` version that the other modules are currently locked to. In fact, that is
+the first stage of the release process, its just under the name
+`monocdk-experiment`. This was a low cost way for the dev team, contributors,
+and users to experiment with the new structure before investing too much towards
+it.
 
-Regardless, the point of using this change to push towards a v2 release, is that the single package structure is "the
-new cdk". Meaning, the long term plan is to only release the `aws-cdk-lib` package and no longer publish the other
-`@aws-cdk/` namespaced ones. The [MonoCDK RFC](https://github.com/aws/aws-cdk-rfcs/issues/6) has more info on the
-problems currently experienced by users caused by the current packaging strategy and these problems will always exist
-unless we stop supporting the `@aws-cdk/` packages.
+Regardless, the point of using this change to push towards a v2 release, is that
+the single package structure is "the new cdk". Meaning, the long term plan is to
+only release the `aws-cdk-lib` package and no longer publish the other
+`@aws-cdk/` namespaced ones. The
+[MonoCDK RFC](https://github.com/aws/aws-cdk-rfcs/issues/6) has more info on the
+problems currently experienced by users caused by the current packaging strategy
+and these problems will always exist unless we stop supporting the `@aws-cdk/`
+packages.
 
-Since we want to eventually supplant the current module structure with the new one, semver says we have to do it with
-the release of a major version.
+Since we want to eventually supplant the current module structure with the new
+one, semver says we have to do it with the release of a major version.
 
 ## Removal of @deprecated APIs - Why not remove these by hand?
 
-An alternative that was considered is to remove these by hand in the `v2` branch. As of Aug 24, 2020, there are ~250
-deprecated properties, methods and classes combined, distributed across ~80 files.
+An alternative that was considered is to remove these by hand in the `v2`
+branch. As of Aug 24, 2020, there are ~250 deprecated properties, methods and
+classes combined, distributed across ~80 files.
 
-While most of these would be properties and simple public APIs being deprecated, they also include larger sections
-such as entire classes. The main challenge with this approach are the merge conflicts that will arise when merging
-changes from the `master` branch onto the `v2` branch.
+While most of these would be properties and simple public APIs being deprecated,
+they also include larger sections such as entire classes. The main challenge
+with this approach are the merge conflicts that will arise when merging changes
+from the `master` branch onto the `v2` branch.
 
-Simple changes to files that contain a few deprecated APIs will pose no difficulty in `git` resolving these conflicts.
-However, any changes to the implementation of a deprecated API, file refactor or any other major changes will require
-non-trivial human intervention. It is unclear who owns the resolution of these conflicts, at what point they will be
-resolved (i.e., during PR, during forward merge, during pipeline approval).
+Simple changes to files that contain a few deprecated APIs will pose no
+difficulty in `git` resolving these conflicts. However, any changes to the
+implementation of a deprecated API, file refactor or any other major changes
+will require non-trivial human intervention. It is unclear who owns the
+resolution of these conflicts, at what point they will be resolved (i.e., during
+PR, during forward merge, during pipeline approval).
 
-We expect the forked state of the system (i.e., two active branches) to exist for several months as we work through the
-changes to have 'CDK 2.0' generally available. As we get closer to 'CDK v2.0', we must expect the list of major changes
-to this major release to expand. This may manifest as major or significant changes to the code and its structure.
-We must also expect an increased rate of deprecated APIs across the CDK as the reality of CDKv2 gets closer, with the
-team looking to use this opportunity to implement major changes.
+We expect the forked state of the system (i.e., two active branches) to exist
+for several months as we work through the changes to have 'CDK 2.0' generally
+available. As we get closer to 'CDK v2.0', we must expect the list of major
+changes to this major release to expand. This may manifest as major or
+significant changes to the code and its structure. We must also expect an
+increased rate of deprecated APIs across the CDK as the reality of CDKv2 gets
+closer, with the team looking to use this opportunity to implement major
+changes.
 
-The continuous overhead of conflict resolution or a ban on large refactors or changes is an unreasonable expectation on
-the team for such an extended period of time.
+The continuous overhead of conflict resolution or a ban on large refactors or
+changes is an unreasonable expectation on the team for such an extended period
+of time.
 
 # Adoption Strategy
 
 All users will perform the following to adopt CDK v2
 
-1. Update Dependencies - Changing from referencing the old `@aws-cdk/` packages to the new `aws-cdk-lib` package in the
-   corresponding target language's package manifest (`package.json`, `.csproj`, `pom.xml`, `setup.py`, etc...).
-1. Update Imports - Since the current module structure is being changed in certain languages, import statements in
-   user's code will need to change accordingly:
-   - In TypeScript, this can be automated by a tool such as `@monocdk-experiment/import-rewriter`
+1. Update Dependencies - Changing from referencing the old `@aws-cdk/` packages
+   to the new `aws-cdk-lib` package in the corresponding target language's
+   package manifest (`package.json`, `.csproj`, `pom.xml`, `setup.py`, etc...).
+1. Update Imports - Since the current module structure is being changed in
+   certain languages, import statements in user's code will need to change
+   accordingly:
+   - In TypeScript, this can be automated by a tool such as
+     `@monocdk-experiment/import-rewriter`
    - In Python, manual replacement of import statements migth be necessary
-   - In .NET languages (C#, F#, ...) and Java, the namespace structure from CDK v1 will be retained, removing the need
-     for any code change
-1. Adjust code to the removal of the constructs compatibility layer, which is documented in [RFC-192]
+   - In .NET languages (C#, F#, ...) and Java, the namespace structure from CDK
+     v1 will be retained, removing the need for any code change
+1. Adjust code to the removal of the constructs compatibility layer, which is
+   documented in [RFC-192]
 
-Users will naturally have to make additional changes when upgrading if they are relying on deprecated APIs or _old
-behaviors_ from feature flags that are being removed. A [migration guide](#migration-guide) will be written with details
-about each individual feature flag and deprecated API that users may need to handle differently when upgrading.
+Users will naturally have to make additional changes when upgrading if they are
+relying on deprecated APIs or _old behaviors_ from feature flags that are being
+removed. A [migration guide](#migration-guide) will be written with details
+about each individual feature flag and deprecated API that users may need to
+handle differently when upgrading.
 
 # Future Possibilities
 
-As our first major version post v1, this sets the tone for others going forward. The v2 release is looking to be
-relatively painless for users to adopt. The most prevalent code change required, if any at all, should be automatable.
-The challenge for the future is to maintain that experience whenever possible, and wherever it isn't, give users plenty
-of time and warning to change their code and provide details about a reasonable path to do so without interruptions to
+As our first major version post v1, this sets the tone for others going forward.
+The v2 release is looking to be relatively painless for users to adopt. The most
+prevalent code change required, if any at all, should be automatable. The
+challenge for the future is to maintain that experience whenever possible, and
+wherever it isn't, give users plenty of time and warning to change their code
+and provide details about a reasonable path to do so without interruptions to
 their existing cloud resources.
 
 # Execution Plan
 
-See GitHub Project Board: [aws/aws-cdk@10](https://github.com/aws/aws-cdk/projects/10)
+See GitHub Project Board:
+[aws/aws-cdk@10](https://github.com/aws/aws-cdk/projects/10)
 
 Changes needed in auxiliary projects:
 
 - **jsii** - Improved prerelease support in _jsii_ (and jsii-pacmak)
-  - Allowing per-language tuning of prerelease versions (Python uses some suffixes, Java uses -SNAPSHOT, NuGet & NPM use
-    semver prerelease labels)
+  - Allowing per-language tuning of prerelease versions (Python uses some
+    suffixes, Java uses -SNAPSHOT, NuGet & NPM use semver prerelease labels)
 - **jsii** - Support for submodule-level README.md for the documentation site
 - **jsii** - Support for multiple versions on a single docsite
 - **DelivLib** - Support for prerelease publishing
@@ -574,10 +713,11 @@ Changes needed in auxiliary projects:
 
 ## Annex 1
 
-Packages that are included in the monolithic library bundle (`monocdk-experiment` to become `aws-cdk-lib`) are the
-following:
+Packages that are included in the monolithic library bundle
+(`monocdk-experiment` to become `aws-cdk-lib`) are the following:
 
-- All non-deprecated packages whith a name starting with `@aws-cdk/aws-` or `@aws-cdk/alexa-`:
+- All non-deprecated packages whith a name starting with `@aws-cdk/aws-` or
+  `@aws-cdk/alexa-`:
   - `@aws-cdk/alexa-ask`
   - `@aws-cdk/aws-accessanalyzer`
   - `@aws-cdk/aws-acmpca`

--- a/text/0092-asset-publishing.md
+++ b/text/0092-asset-publishing.md
@@ -1,49 +1,71 @@
 # cdk-assets
 
-`cdk-assets` is a tool in the AWS CDK toolchain responsible to package and publish assets as part of the deployment process of CDK applications.
+`cdk-assets` is a tool in the AWS CDK toolchain responsible to package and
+publish assets as part of the deployment process of CDK applications.
 
-This document specifies the requirements for this tool derived from the [continuous delivery design document](./continuous-delivery.md).
+This document specifies the requirements for this tool derived from the
+[continuous delivery design document](./continuous-delivery.md).
 
 ## Assumptions
 
-* Similarly to any resource defined through code and managed through CloudFormation, we are not attempting to protect assets from manual tampering by
-  users.
+- Similarly to any resource defined through code and managed through
+  CloudFormation, we are not attempting to protect assets from manual tampering
+  by users.
 
 ## Asset Manifest
 
-The main input to `cdk-assets` is a JSON file called `assets.json` which includes a manifest of assets.
+The main input to `cdk-assets` is a JSON file called `assets.json` which
+includes a manifest of assets.
 
-The manifest lists all assets and for each asset it describes the asset **source** (with instructions on how to package the asset if needed) and a
-list of **destinations**, which are locations into which this asset needs to be published.
+The manifest lists all assets and for each asset it describes the asset
+**source** (with instructions on how to package the asset if needed) and a list
+of **destinations**, which are locations into which this asset needs to be
+published.
 
 The main components of the assets manifest are:
 
-* **Types:** there are currently two supported types: files and docker images. Files are uploaded to an Amazon S3 bucket and docker images are pushed
-  to an Amazon ECR repository.
+- **Types:** there are currently two supported types: files and docker images.
+  Files are uploaded to an Amazon S3 bucket and docker images are pushed to an
+  Amazon ECR repository.
 
-* **Identifiers:** assets are identified throughout the system via a unique identifier (the key in the `files` and `images` map). This identifier is
-  based on the sha256 of the source (the contents of the file or directory) and will change only if the source changes. It can be used for local
-  caching and optimization purposes. For example, a zip of a directory can be stored in a local cache by this identifier to avoid duplicate work.
+- **Identifiers:** assets are identified throughout the system via a unique
+  identifier (the key in the `files` and `images` map). This identifier is based
+  on the sha256 of the source (the contents of the file or directory) and will
+  change only if the source changes. It can be used for local caching and
+  optimization purposes. For example, a zip of a directory can be stored in a
+  local cache by this identifier to avoid duplicate work.
 
-* **Sources:** the `source` information for each asset defines the file or directory (relative to the directory of `assets.json`), and additional
-  **packaging** instructions, such as whether to create a zip file from a directory (for file assets) or which options to pass to `docker build`.
+- **Sources:** the `source` information for each asset defines the file or
+  directory (relative to the directory of `assets.json`), and additional
+  **packaging** instructions, such as whether to create a zip file from a
+  directory (for file assets) or which options to pass to `docker build`.
 
-* **Destinations:** describe where the asset should be published. At a minimum, for file assets, it includes the S3 bucket and object key and for
-  docker images it includes the repository and image names. A destination may also indicate that an IAM role must be assumed in order to support cross
+- **Destinations:** describe where the asset should be published. At a minimum,
+  for file assets, it includes the S3 bucket and object key and for docker
+  images it includes the repository and image names. A destination may also
+  indicate that an IAM role must be assumed in order to support cross
   environment publishing.
 
 NOTES:
 
-* **Denormalization:** destinations are intentionally denormalized in order to keep the logic of where assets are published at the application or
-  framework level and not in this tool. For example, consider a deployment system which requires that all assets are always published to the same
-  location, and then replicated through some other means to their actual consumption point. Alternatively, a user may have unique security
-  requirements that will require certain assets to be stored in dedicated locations (e.g. with a specific key) and others in a different location,
-  even if they all go to the same environment. Therefore, this tool should not take any assumptions on where assets should be published besides the
-  exact instructions in this file.
-* **Environment-agnostic:** In order to allow assets to be used in environment-agnostic stacks, `assets.json` will support two simple substitutions
-  `${AWS::AccountId}` and `${AWS::Region}` which will be replaced with the currently configured account/region (alternatively, we can also decide to
-  support CloudFormation intrinsic functions and pseudo references). The "current" account and region will always refer to the one derived from the
-  CLI configuration even if `assets.json` instructs to assume a role from a different account.
+- **Denormalization:** destinations are intentionally denormalized in order to
+  keep the logic of where assets are published at the application or framework
+  level and not in this tool. For example, consider a deployment system which
+  requires that all assets are always published to the same location, and then
+  replicated through some other means to their actual consumption point.
+  Alternatively, a user may have unique security requirements that will require
+  certain assets to be stored in dedicated locations (e.g. with a specific key)
+  and others in a different location, even if they all go to the same
+  environment. Therefore, this tool should not take any assumptions on where
+  assets should be published besides the exact instructions in this file.
+- **Environment-agnostic:** In order to allow assets to be used in
+  environment-agnostic stacks, `assets.json` will support two simple
+  substitutions `${AWS::AccountId}` and `${AWS::Region}` which will be replaced
+  with the currently configured account/region (alternatively, we can also
+  decide to support CloudFormation intrinsic functions and pseudo references).
+  The "current" account and region will always refer to the one derived from the
+  CLI configuration even if `assets.json` instructs to assume a role from a
+  different account.
 
 Here is the complete manifest file schema in typescript:
 
@@ -65,40 +87,41 @@ interface ImageAsset {
 }
 
 interface FileAssetSource {
-  readonly file: string;                                // file or directory name, relative to basedir
-  readonly packaging?: FileAssetPackaging;              // packaging (default "FILE")
+  readonly file: string; // file or directory name, relative to basedir
+  readonly packaging?: FileAssetPackaging; // packaging (default "FILE")
 }
 
 enum FileAssetPackaging {
-  FILE = 'file',                                        // just upload "file" as-is
-  ZIP_DIRECTORY = 'zip'                                 // zip the directory and then upload
+  FILE = 'file', // just upload "file" as-is
+  ZIP_DIRECTORY = 'zip', // zip the directory and then upload
 }
 
 interface FileAssetDestination {
-  readonly assumeRoleArn?: string;                      // iam role to assume
-  readonly assumeRoleExternalId?: string;               // external id to pass to assume-role
+  readonly assumeRoleArn?: string; // iam role to assume
+  readonly assumeRoleExternalId?: string; // external id to pass to assume-role
   readonly region: string;
   readonly bucketName: string;
   readonly objectKey: string;
 }
 
 interface ImageAssetSource {
-  readonly directory: string;                           // docker build context directory
+  readonly directory: string; // docker build context directory
   readonly dockerBuildArgs?: { [arg: string]: string }; // optional args to "docker build"
-  readonly dockerBuildTarget?: string;                  // docker build --target to use
-  readonly dockerFile?: string;                         // custom name for Dockerfile
+  readonly dockerBuildTarget?: string; // docker build --target to use
+  readonly dockerFile?: string; // custom name for Dockerfile
 }
 
 interface ImageAssetDestination {
   readonly region: string;
-  readonly assumeRoleArn: string;                       // iam role to assume
-  readonly assumeRoleExternalId?: string;               // external id to pass to assume-role
-  readonly repositoryName: string;                      // ECR repository name
-  readonly imageName: string;                           // image tag to use
+  readonly assumeRoleArn: string; // iam role to assume
+  readonly assumeRoleExternalId?: string; // external id to pass to assume-role
+  readonly repositoryName: string; // ECR repository name
+  readonly imageName: string; // image tag to use
 }
 ```
 
-Example of `assets.json` with two assets: a docker image and a file asset. Both assets are published to two destinations (S3/ECR).
+Example of `assets.json` with two assets: a docker image and a file asset. Both
+assets are published to two destinations (S3/ECR).
 
 ```json
 {
@@ -150,7 +173,8 @@ Example of `assets.json` with two assets: a docker image and a file asset. Both 
 
 ## API
 
-`cdk-assets` is designed as a stand-alone command line program and a library, so it can be integrated into other tools such as the CDK CLI or executed
+`cdk-assets` is designed as a stand-alone command line program and a library, so
+it can be integrated into other tools such as the CDK CLI or executed
 individually as a step in a CI/CD pipeline.
 
 ### `publish`
@@ -161,9 +185,11 @@ cdk-assets publish DIR [ASSET-ID,ASSET-ID...]
 
 Packages and publishes assets to all destinations.
 
-* `DIR` is the directory from where to read `assets.json`, and which is used as the base directory for all file/directory references.
-* `ASSET-ID,...`: additional arguments represent asset identifiers to publish (default is to publish all assets). This can be used to implement
-  concurrent publishing of assets (e.g. through CodePipeline).
+- `DIR` is the directory from where to read `assets.json`, and which is used as
+  the base directory for all file/directory references.
+- `ASSET-ID,...`: additional arguments represent asset identifiers to publish
+  (default is to publish all assets). This can be used to implement concurrent
+  publishing of assets (e.g. through CodePipeline).
 
 The `publish` command will do the following:
 
@@ -180,8 +206,9 @@ for each asset in manifest:
     publish to destination (upload/push)
 ```
 
-> When we execute this tool in a CodeBuild project, we should enable [local
-> caching](https://docs.aws.amazon.com/codebuild/latest/userguide/build-caching.html#caching-local) of docker images as an optimization.
+> When we execute this tool in a CodeBuild project, we should enable
+> [local caching](https://docs.aws.amazon.com/codebuild/latest/userguide/build-caching.html#caching-local)
+> of docker images as an optimization.
 
 Example (`cdk.out/assets.json` as above):
 
@@ -209,14 +236,21 @@ done     a0bae29e7b47044a66819606c65d26a92b1e844f4b3124a5539efc0167a09e57
 
 The log above describes the following:
 
-The first asset to process is the docker image with id `d31ca1a...`. We first assume the role is the 2222US environment and check if the image exists
-in this ECR repository. Since it doesn't exist (`notfound`), we check if it exists in the local cache under the tag
-`d31ca1aef8d1b68217852e7aea70b1e857d107b47637d5160f9f9a1b24882d2a`. It doesn't so we build the docker image (`package`) and then push it. Then we
-assume the role from the 33333EU environment and find that the image is already in that ECR repository, so we just finish.
+The first asset to process is the docker image with id `d31ca1a...`. We first
+assume the role is the 2222US environment and check if the image exists in this
+ECR repository. Since it doesn't exist (`notfound`), we check if it exists in
+the local cache under the tag
+`d31ca1aef8d1b68217852e7aea70b1e857d107b47637d5160f9f9a1b24882d2a`. It doesn't
+so we build the docker image (`package`) and then push it. Then we assume the
+role from the 33333EU environment and find that the image is already in that ECR
+repository, so we just finish.
 
-The second asset is the file asset with id `a0bae...`. The first environment doesn't specify a role, so we just check if the file exists in the S3
-bucket. It is, so we move to the next destination. We assume the role and check if the asset is in the s3 location. It is not (`notfound`), so we need
-to package and upload it. Before we package we check if it's cached locally and find that it is (`cached`), so no need to zip again, just `upload`.
+The second asset is the file asset with id `a0bae...`. The first environment
+doesn't specify a role, so we just check if the file exists in the S3 bucket. It
+is, so we move to the next destination. We assume the role and check if the
+asset is in the s3 location. It is not (`notfound`), so we need to package and
+upload it. Before we package we check if it's cached locally and find that it is
+(`cached`), so no need to zip again, just `upload`.
 
 ### `ls`
 
@@ -238,11 +272,13 @@ This information is purely based on the contents of `assets.json`.
 
 ### Programmatic API
 
-The tool should expose a programmatic (library) API, so it can be integrated with other tools such as the AWS CLI and IDEs. The library should be
+The tool should expose a programmatic (library) API, so it can be integrated
+with other tools such as the AWS CLI and IDEs. The library should be
 jsii-compliant and released to all languages supported by the AWS CDK.
 
-Since the publishing process is highly asynchronous, the API should include the ability to subscribe to progress events in order to allow
-implementation of a rich user interface.
+Since the publishing process is highly asynchronous, the API should include the
+ability to subscribe to progress events in order to allow implementation of a
+rich user interface.
 
 Proposed API:
 
@@ -250,7 +286,7 @@ Proposed API:
 class Assets {
   constructor(dir: string);
   readonly manifest: AssetManifest;
-  
+
   // starts publishing a single asset
   publish(assetid: string, progress?: Progress): Publish;
 }
@@ -278,8 +314,11 @@ class Publish {
 
 ## Non-Functional Requirements
 
-* **test coverage**: codebase must have full unit test coverage and a set of integration tests that can be executed within a pipeline environment.
-* **minimal dependencies**: the tool should take the minimum amount of 3rd party dependencies in order to reduce attack surface and to simplify
-  bundling for jsii.
-* **jsii**: the API must be jsii-complient, so it can be used programmatically from all supported languages. This means that all non-jsii dependencies
-  must be bundled into the module.
+- **test coverage**: codebase must have full unit test coverage and a set of
+  integration tests that can be executed within a pipeline environment.
+- **minimal dependencies**: the tool should take the minimum amount of 3rd party
+  dependencies in order to reduce attack surface and to simplify bundling for
+  jsii.
+- **jsii**: the API must be jsii-complient, so it can be used programmatically
+  from all supported languages. This means that all non-jsii dependencies must
+  be bundled into the module.

--- a/text/0095-cognito-construct-library.md
+++ b/text/0095-cognito-construct-library.md
@@ -11,17 +11,21 @@ This RFC covers the design of Cognito's CDK construct library coverage.
 
 # Motivation
 
-The CDK constructs that are currently available in the CDK have a decent level of usage among customers. However, the
-current usage is via the 'Cfn' constructs and some basic features available via the `UserPool` construct. The current
-implementation of the `UserPool` construct only covers sign in type, user pool attributes and triggers.
+The CDK constructs that are currently available in the CDK have a decent level
+of usage among customers. However, the current usage is via the 'Cfn' constructs
+and some basic features available via the `UserPool` construct. The current
+implementation of the `UserPool` construct only covers sign in type, user pool
+attributes and triggers.
 
-The goal of this RFC is to review the current `UserPool` construct for ergonomics in usability and extensibility, and
-to extend the features covered by the Cognito module.
+The goal of this RFC is to review the current `UserPool` construct for
+ergonomics in usability and extensibility, and to extend the features covered by
+the Cognito module.
 
 # Design Summary
 
-This RFC is structured as a working backwards document. Since the focus of this RFC is to propose the API design, the
-best way to propose this is to write up the future user guide of the Cognito module, as if it was complete.
+This RFC is structured as a working backwards document. Since the focus of this
+RFC is to propose the API design, the best way to propose this is to write up
+the future user guide of the Cognito module, as if it was complete.
 
 The bulk of the RFC is in the supporting document -
 [working-backwards-readme.md](./0095-cognito-construct-library/working-backwards-readme.md)
@@ -30,19 +34,22 @@ The bulk of the RFC is in the supporting document -
 
 The design creates a couple of entry points for getting into the Cognito APIs.
 
-The first is the `UserPool` construct. The UserPool resource type itself can be fully configured via its constructor.
-Further resource types that are based on user pool, such as, user pool user, client, etc. can configured from this.
+The first is the `UserPool` construct. The UserPool resource type itself can be
+fully configured via its constructor. Further resource types that are based on
+user pool, such as, user pool user, client, etc. can configured from this.
 
-The other entry point is the `IdentityPool` construct. Similar to the user pool, all subsequent resource types that are
-based on the identity pool, can be created and configured from this.
+The other entry point is the `IdentityPool` construct. Similar to the user pool,
+all subsequent resource types that are based on the identity pool, can be
+created and configured from this.
 
 # Adoption Strategy
 
-The proposal looks to adhere as close to the existing set of `UserPool` APIs as possible, so any breaking change to the
-current APIs is easy and quick to resolve.
+The proposal looks to adhere as close to the existing set of `UserPool` APIs as
+possible, so any breaking change to the current APIs is easy and quick to
+resolve.
 
-The Cognito module's API stability is 'experimental'. This is a signal to the users of this module that breaking
-changes to the API are to be expected.
+The Cognito module's API stability is 'experimental'. This is a signal to the
+users of this module that breaking changes to the API are to be expected.
 
 # Unresolved questions
 
@@ -50,27 +57,33 @@ None.
 
 # Future Changes / Currently out of scope
 
-The following are currently out of scope for this document. Separate issues will be created for these, that will then
-be prioritized based on customer requests and +1s.
+The following are currently out of scope for this document. Separate issues will
+be created for these, that will then be prioritized based on customer requests
+and +1s.
 
-* User Pool
-  * Import using user pool name
-  * Configure SES email actions.
-  * ClientMetadata and ValidationData properties in User
-  * Support for [Clients and HostedUI](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-app-integration.html)
-  * [Identity providers](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-identity-federation.html)
-  * [Advanced security features](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-advanced-security.html)
-* Identity Pool
-  * External provider - Cognito. This requires CDK coverage of user pool clients (above). While it's available via the
-    APIs and CloudFormation resources, it is [not listed in the
-    documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/external-identity-providers.html) as one
-    of the identity providers, so it might not be a sought after feature.
-  * External provider - OpenId connect. This requires coverage for OIDC identity providers in the IAM module.
-  * External provider - SAML. This requires coverage for SAML identity providers in the IAM module.
-  * Token based access control - Requires Cognito user pool clients (above).
+- User Pool
+  - Import using user pool name
+  - Configure SES email actions.
+  - ClientMetadata and ValidationData properties in User
+  - Support for
+    [Clients and HostedUI](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-app-integration.html)
+  - [Identity providers](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-identity-federation.html)
+  - [Advanced security features](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-advanced-security.html)
+- Identity Pool
+  - External provider - Cognito. This requires CDK coverage of user pool clients
+    (above). While it's available via the APIs and CloudFormation resources, it
+    is
+    [not listed in the documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/external-identity-providers.html)
+    as one of the identity providers, so it might not be a sought after feature.
+  - External provider - OpenId connect. This requires coverage for OIDC identity
+    providers in the IAM module.
+  - External provider - SAML. This requires coverage for SAML identity providers
+    in the IAM module.
+  - Token based access control - Requires Cognito user pool clients (above).
 
-The following are out of scope of this document and are unlikely to be implemented.
+The following are out of scope of this document and are unlikely to be
+implemented.
 
-* Identity pool cognito sync. Reason:
-  [Documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-sync.html) suggests the use of AWS
-  AppSync instead.
+- Identity pool cognito sync. Reason:
+  [Documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-sync.html)
+  suggests the use of AWS AppSync instead.

--- a/text/0107-construct-library-module-lifecycle.md
+++ b/text/0107-construct-library-module-lifecycle.md
@@ -9,20 +9,23 @@ related issue: https://github.com/aws/aws-cdk-rfcs/issues/107
 
 ## Summary
 
-The purpose of this document is to outline the process used to prioritize and mature modules in the AWS-CDK Construct
-Library. It outlines how we graduate modules from CloudFormation-only resources to modules that contain high-level
+The purpose of this document is to outline the process used to prioritize and
+mature modules in the AWS-CDK Construct Library. It outlines how we graduate
+modules from CloudFormation-only resources to modules that contain high-level
 resource abstractions and stabilize them for GA release.
 
 ## Motivation
 
-We want to be transparent about the processes the AWS CDK team use, and seek community input to make them better. To
-that end this living document will be published on the AWS CDK GitHub repo Wiki, and linked to from the repo's main
+We want to be transparent about the processes the AWS CDK team use, and seek
+community input to make them better. To that end this living document will be
+published on the AWS CDK GitHub repo Wiki, and linked to from the repo's main
 README and the public roadmap README.
 
 ## Stages of an AWS-CDK Construct Library Module
 
-The sections below outline the development stages for modules in the AWS-CDK Construct Library and the criteria to
-graduate the module to the next level of maturity. There are 4 stages of development for an AWS-CDK Construct Library
+The sections below outline the development stages for modules in the AWS-CDK
+Construct Library and the criteria to graduate the module to the next level of
+maturity. There are 4 stages of development for an AWS-CDK Construct Library
 module:
 
 - Stage 0 - CFN Resources
@@ -32,23 +35,28 @@ module:
 
 Each stage in this document describes 3 distinct sets of activities:
 
-* **Entry activities:** Actions that need to be taken before the module enters this stage. These can either be automatic, or done by the team.
-They will be performed as soon as the module moves into the new stage.
-* **Ongoing activities:** These are the activities that are primarily performed during when a module is in a specific stage (e.g bug fixes, new features...).
-* **Exit criteria:** When these criteria are all met, a module can progress into the next stage.
-Note that, while all of the criteria here are necessary, they may not be sufficient. The module still needs to be chosen for
-maturation using the [prioritization framework](#Construct-prioritization-framework).
+- **Entry activities:** Actions that need to be taken before the module enters
+  this stage. These can either be automatic, or done by the team. They will be
+  performed as soon as the module moves into the new stage.
+- **Ongoing activities:** These are the activities that are primarily performed
+  during when a module is in a specific stage (e.g bug fixes, new features...).
+- **Exit criteria:** When these criteria are all met, a module can progress into
+  the next stage. Note that, while all of the criteria here are necessary, they
+  may not be sufficient. The module still needs to be chosen for maturation
+  using the [prioritization framework](#Construct-prioritization-framework).
 
 ## Stage 0 - CFN Resources
 
-All construct library modules start in stage 0 when they are auto-generated from the CloudFormation resource
-specification. The goal of stage 0 is to make new CloudFormation resources/properties available to CDK customers as soon
-as possible, and create tracking artifacts that allow us to capture the data required to make prioritization decisions
-to add L2 resources in the future.
+All construct library modules start in stage 0 when they are auto-generated from
+the CloudFormation resource specification. The goal of stage 0 is to make new
+CloudFormation resources/properties available to CDK customers as soon as
+possible, and create tracking artifacts that allow us to capture the data
+required to make prioritization decisions to add L2 resources in the future.
 
 ### Entry activities
 
-> The following actions are performed automatically during the weekly CDK release process:
+> The following actions are performed automatically during the weekly CDK
+> release process:
 >
 > - Generation of the module L1 code when CFN introduces a new spec.
 > - Generation of the initial module README.
@@ -56,22 +64,28 @@ to add L2 resources in the future.
 >
 > The remaining activities described here need to be done manually.
 
-- **Create GitHub tracking issue** - Create a GitHub tracking issue for the module. The primary role of the tracking
-  issue is to:
-  - provide an artifact that represents an entire AWS service that customers can +1 to help us prioritize, and
-  - provide a single artifact to place on the public roadmap to indicate work in progress.
+- **Create GitHub tracking issue** - Create a GitHub tracking issue for the
+  module. The primary role of the tracking issue is to:
 
-- **Validate API reference** - Validate the module is listed in the AWS Construct Library API reference and is
-  rendered correctly
+  - provide an artifact that represents an entire AWS service that customers can
+    +1 to help us prioritize, and
+  - provide a single artifact to place on the public roadmap to indicate work in
+    progress.
+
+- **Validate API reference** - Validate the module is listed in the AWS
+  Construct Library API reference and is rendered correctly
 
 ### Ongoing activities
 
-- **Observe** - Watch KPIs to prioritize the construct library module's graduation:
-  - pull requests that add the first high-level constructs are the strongest signal to graduate a construct library
-    module from stage 0 to stage 1 (experimental) and are prioritized first (this is a manual activity)
-  - customer "+1s" on a construct library module's tracking issue exceeding 100 positive reactions, are prioritized
-    next
-  - construct library modules that accumulate 10+ feature requests, are prioritized next
+- **Observe** - Watch KPIs to prioritize the construct library module's
+  graduation:
+  - pull requests that add the first high-level constructs are the strongest
+    signal to graduate a construct library module from stage 0 to stage 1
+    (experimental) and are prioritized first (this is a manual activity)
+  - customer "+1s" on a construct library module's tracking issue exceeding 100
+    positive reactions, are prioritized next
+  - construct library modules that accumulate 10+ feature requests, are
+    prioritized next
 
 ### Exit Criteria
 
@@ -79,153 +93,193 @@ to add L2 resources in the future.
 
 ## Stage 1 - Experimental
 
-The goal of the experimental stage is to iterate on the design and functionality of a construct library module with the
-freedom, and understanding of customers, to make breaking changes when desirable or necessary. During this stage the
-primary use cases and the set of L2 constructs required to enable them are incrementally identified, implemented, and
-validated.
+The goal of the experimental stage is to iterate on the design and functionality
+of a construct library module with the freedom, and understanding of customers,
+to make breaking changes when desirable or necessary. During this stage the
+primary use cases and the set of L2 constructs required to enable them are
+incrementally identified, implemented, and validated.
 
-While experimenting on the module API design and implementation, we will be as transparent as possible with customers
-about the work in progress. To achieve this we will use the module’s GitHub tracking issue to document use cases and
-construct design as they are developed in each iteration. Not all communication is required to occur in the tracking
-issue itself. For large and/or complex changes, we will author a Request for Comments (RFC) that outlines our design and
-publish it on the roadmap for feedback. We will also use pull requests to conduct construct reviews. In all cases,
-relevant RFCs, PRs, bugs, and feature requests that are in scope are linked in the module’s tracking issue for
-visibility. See [Appendix A](#Appendix-A:-GitHub-Artifacts) for an illustration of how these GitHub artifacts are used
-and related to each other.
+While experimenting on the module API design and implementation, we will be as
+transparent as possible with customers about the work in progress. To achieve
+this we will use the module’s GitHub tracking issue to document use cases and
+construct design as they are developed in each iteration. Not all communication
+is required to occur in the tracking issue itself. For large and/or complex
+changes, we will author a Request for Comments (RFC) that outlines our design
+and publish it on the roadmap for feedback. We will also use pull requests to
+conduct construct reviews. In all cases, relevant RFCs, PRs, bugs, and feature
+requests that are in scope are linked in the module’s tracking issue for
+visibility. See [Appendix A](#Appendix-A:-GitHub-Artifacts) for an illustration
+of how these GitHub artifacts are used and related to each other.
 
 ### Entry activities
 
-- **Identify key stakeholders** - Opportunistically recruit stakeholders outside the CDK team to participate in API
-  reviews and usability studies. Potential stakeholders include:
+- **Identify key stakeholders** - Opportunistically recruit stakeholders outside
+  the CDK team to participate in API reviews and usability studies. Potential
+  stakeholders include:
+
   - service's product manager,
   - service's developer advocates (if any),
-  - service's software development engineer(s) (designated by service's leadership),
+  - service's software development engineer(s) (designated by service's
+    leadership),
   - solutions architects who specialize in service,
   - AWS Developer Tools developer advocates
 
-- **Update GitHub tracking issue** - List the primary use cases for the service and the constructs required to satisfy
-  them. This is an iterative process, so the full set of use cases and constructs are not expected to be defined at
-  the start of this stage.
+- **Update GitHub tracking issue** - List the primary use cases for the service
+  and the constructs required to satisfy them. This is an iterative process, so
+  the full set of use cases and constructs are not expected to be defined at the
+  start of this stage.
 
-  - Defining the service's "getting started" scenario in CDK code is an ideal first use case to enable
+  - Defining the service's "getting started" scenario in CDK code is an ideal
+    first use case to enable
 
-- **Author RFCs [optional]** - Request for comment documents are created for large / complex designs that require
-  explanation and robust discussion. RFCs are stored in a separate [GitHub repo](https://github.com/aws/aws-cdk-rfcs),
+- **Author RFCs [optional]** - Request for comment documents are created for
+  large / complex designs that require explanation and robust discussion. RFCs
+  are stored in a separate [GitHub repo](https://github.com/aws/aws-cdk-rfcs),
   and the module's tracking issue will include links to relevant RFCs.
 
 - **Update Roadmap** - Publicly indicate the module is work in progress
-  - if an RFC is written, place the module’s tracking issue on the CDK roadmap in the “Researching” column to indicate
-    we need customer feedback on the module’s design. When the RFC process is complete, move the tracking issue to the
-    "Working on it" column
-  - otherwise, place the module’s tracking issue on the CDK roadmap in the “Working on it“ column
+  - if an RFC is written, place the module’s tracking issue on the CDK roadmap
+    in the “Researching” column to indicate we need customer feedback on the
+    module’s design. When the RFC process is complete, move the tracking issue
+    to the "Working on it" column
+  - otherwise, place the module’s tracking issue on the CDK roadmap in the
+    “Working on it“ column
 
 ### Ongoing activities
 
-- **Submit Pull Requests** - Pull requests implementing the constructs are submitted, the API design reviewed (by
-  module owner), and merged
+- **Submit Pull Requests** - Pull requests implementing the constructs are
+  submitted, the API design reviewed (by module owner), and merged
 
-- **Documentation** - Update module’s README with explanations and code snippets that illustrate how to use new
-  constructs as they are developed
+- **Documentation** - Update module’s README with explanations and code snippets
+  that illustrate how to use new constructs as they are developed
 
-- **Observe** - Monitor GitHub issues filed against the experimental module and module utilization metrics
-  - feature requests and bugs filed against the experimental module are triaged, and those that we decide to include
-    in the module are linked in the tracking issue to indicate they are in scope. All P0 issues are fixed immediately,
-    P1 issues are in scope for GA release, and P2 issues are deferred until we accumulate enough feedback to change
-    its priority.
+- **Observe** - Monitor GitHub issues filed against the experimental module and
+  module utilization metrics
 
-- **Repeat** - These activities are repeated until the module owner decides the module is feature complete and the API
-  is ergonomic. At the end of the experimental stage, the construct library module’s GitHub tracking issue will have a
-  description of the service, a list of targeted use cases, and a list of high-level constructs required to satisfy
-  the use cases.
+  - feature requests and bugs filed against the experimental module are triaged,
+    and those that we decide to include in the module are linked in the tracking
+    issue to indicate they are in scope. All P0 issues are fixed immediately, P1
+    issues are in scope for GA release, and P2 issues are deferred until we
+    accumulate enough feedback to change its priority.
+
+- **Repeat** - These activities are repeated until the module owner decides the
+  module is feature complete and the API is ergonomic. At the end of the
+  experimental stage, the construct library module’s GitHub tracking issue will
+  have a description of the service, a list of targeted use cases, and a list of
+  high-level constructs required to satisfy the use cases.
 
 ### Exit Criteria
 
-- **Major Use Cases Addressed** - During each iteration in the experimental phase, a module's Github tracking issue will
-  accumulate a checklist of major use cases. Every quarter, as part of the construct library module prioritization,
-  owners look at the checklists for their module and if most/all of them are checked off, it is considered as a
-  developer preview candidate.
+- **Major Use Cases Addressed** - During each iteration in the experimental
+  phase, a module's Github tracking issue will accumulate a checklist of major
+  use cases. Every quarter, as part of the construct library module
+  prioritization, owners look at the checklists for their module and if most/all
+  of them are checked off, it is considered as a developer preview candidate.
 
-  > **Note**: This does not imply 100% AWS service feature coverage, instead, it means the module owner
-  > thinks we’ve implemented the minimum features required for a delightful developer experience for modeling the
-  > service infrastructure as code.
+  > **Note**: This does not imply 100% AWS service feature coverage, instead, it
+  > means the module owner thinks we’ve implemented the minimum features
+  > required for a delightful developer experience for modeling the service
+  > infrastructure as code.
 
-- **Successful Security review** - All policies and security sensitive commits are reviewed and approved by AppSec.
+- **Successful Security review** - All policies and security sensitive commits
+  are reviewed and approved by AppSec.
 
-- **Successful API review** - Conduct an API review/developer experience demo and invite relevant stakeholders
+- **Successful API review** - Conduct an API review/developer experience demo
+  and invite relevant stakeholders
   - use module's README as the API review guide
   - address any concerns about API ergonomics
   - review all AWS Lint exceptions to ensure they are acceptable for dev preview
   - ensure at least 90% unit test coverage for all implemented L2 constructs
-  - if the API/DevEx is rejected, make a list of necessary remediation tasks and update the module's tracking issue
+  - if the API/DevEx is rejected, make a list of necessary remediation tasks and
+    update the module's tracking issue
 
 ## Stage 2 - Developer Preview
 
-The goal of developer preview is to deliver a release candidate with a stable API to conduct user acceptance testing and
-accumulate sufficient usage to declare a module is ready for general availability. We will only make breaking changes to
-developer preview modules when required to address unforeseen customer use cases or issues. Since the potential for
-breaking changes still remains while in Developer Preview, the package name will keep the "experimental" stability during
-this stage.
+The goal of developer preview is to deliver a release candidate with a stable
+API to conduct user acceptance testing and accumulate sufficient usage to
+declare a module is ready for general availability. We will only make breaking
+changes to developer preview modules when required to address unforeseen
+customer use cases or issues. Since the potential for breaking changes still
+remains while in Developer Preview, the package name will keep the
+"experimental" stability during this stage.
 
 ### Entry activities
 
-- **Update Roadmap** - Move to the CDK public roadmap “Developer Preview” column to indicate we need customer feedback
-  on the module’s implementation
+- **Update Roadmap** - Move to the CDK public roadmap “Developer Preview” column
+  to indicate we need customer feedback on the module’s implementation
 
 ### Ongoing activities
 
-- **Observe** - Monitor GitHub issues filed against the developer preview module and module utilization metrics
-  - feature requests and bugs filed against the developer preview module are triaged, and those that we decide to
-    include in the module are linked in the tracking issue to indicate they are in scope. All P0 issues are fixed
-    immediately, P1 issues are in scope for GA release, and P2 issues are deferred until we accumulate enough feedback
-    to change its priority.
+- **Observe** - Monitor GitHub issues filed against the developer preview module
+  and module utilization metrics
 
-- **Quality Assurance** - Fix all P0 bugs as they are discovered and review all P1 bugs, making a clearly communicated
-  fix/defer decision for each one
+  - feature requests and bugs filed against the developer preview module are
+    triaged, and those that we decide to include in the module are linked in the
+    tracking issue to indicate they are in scope. All P0 issues are fixed
+    immediately, P1 issues are in scope for GA release, and P2 issues are
+    deferred until we accumulate enough feedback to change its priority.
+
+- **Quality Assurance** - Fix all P0 bugs as they are discovered and review all
+  P1 bugs, making a clearly communicated fix/defer decision for each one
 
 ### Exit Criteria
 
-- **Bake time** - Modules will spend at least 3 months in developer preview to accumulate sufficient usage data to
-  gain confidence in the API’s ergonomics and customer acceptance
+- **Bake time** - Modules will spend at least 3 months in developer preview to
+  accumulate sufficient usage data to gain confidence in the API’s ergonomics
+  and customer acceptance
 
-- **Usage** - Module utilization in 2,000 or more stacks is considered sufficient usage. We will evaluate the language
-  distribution of module use to determine if we need to target specific underrepresented programming language
+- **Usage** - Module utilization in 2,000 or more stacks is considered
+  sufficient usage. We will evaluate the language distribution of module use to
+  determine if we need to target specific underrepresented programming language
   communities for feedback
 
 - **No P0 bugs** - No new P0 bugs in the past 4 weeks
 
 ## Stage 3 - GA
 
-The module is generally available with a backwards compatible guarantee across minor versions.
+The module is generally available with a backwards compatible guarantee across
+minor versions.
 
 ### Entry activities
 
-- **Nominate champion** - A member of the Construct Library Squad is assigned as the graduation champion.
+- **Nominate champion** - A member of the Construct Library Squad is assigned as
+  the graduation champion.
 
-- **Create Graduation Issue** - Create a GitHub issue titled `Graduate @aws-cdk/{module} to stable`.
-This issue communicates our intent to graduate this module. It will also serve as an asynchronous channel for anyone who wants to provide feedback.
-Update the module tracking issue with a link to this issue so that the community can be notified.
+- **Create Graduation Issue** - Create a GitHub issue titled
+  `Graduate @aws-cdk/{module} to stable`. This issue communicates our intent to
+  graduate this module. It will also serve as an asynchronous channel for anyone
+  who wants to provide feedback. Update the module tracking issue with a link to
+  this issue so that the community can be notified.
 
-  > External Stakeholders and major community contributors should be contacted directly.
+  > External Stakeholders and major community contributors should be contacted
+  > directly.
 
-  Include a checklist of tasks that must be completed before flipping the switch.
-  Initially, this would be:
+  Include a checklist of tasks that must be completed before flipping the
+  switch. Initially, this would be:
 
-  - **Validate existing bugs** - Make sure there were no *p0* bugs in the last 4 weeks.
-  - **Validate developer experience** - Consult module owners and make sure most major use cases can be configured via CDK.
-  - **Clear awslint exclusions** - Review `awslint` exclusions and make the necessary code changes to remove what we can.
+  - **Validate existing bugs** - Make sure there were no _p0_ bugs in the last 4
+    weeks.
+  - **Validate developer experience** - Consult module owners and make sure most
+    major use cases can be configured via CDK.
+  - **Clear awslint exclusions** - Review `awslint` exclusions and make the
+    necessary code changes to remove what we can.
 
-  The list can grow with additional tasks that are surfaced following the API review.
+  The list can grow with additional tasks that are surfaced following the API
+  review.
 
-  See an example here: [AWS Config Graduation Issue](https://github.com/aws/aws-cdk/issues/5872).
+  See an example here:
+  [AWS Config Graduation Issue](https://github.com/aws/aws-cdk/issues/5872).
+
 - **Conduct API review**
 
   Champion to conduct a final API review.
 
-  > The champion is expected to be relatively versed in the library.
-  > If this requires some effort to achieve, the review should be scheduled with this in mind.
+  > The champion is expected to be relatively versed in the library. If this
+  > requires some effort to achieve, the review should be scheduled with this in
+  > mind.
 
-  The goal of this review is to identify critical API and Security issues.
-  It is meant to be as frictionless and slim as possible. Attendees are:
+  The goal of this review is to identify critical API and Security issues. It is
+  meant to be as frictionless and slim as possible. Attendees are:
 
   - Module owners (Required)
   - Graduation Champion (Required)
@@ -233,46 +287,57 @@ Update the module tracking issue with a link to this issue so that the community
   - External Stakeholders (Optional)
   - Community Contributors (Optional)
 
-  The review will be held over Chime and the invite should be sent no less than a week in advance.
-  This is to give the attendees a chance to prepare if they so desire. Include the agenda in the invite:
+  The review will be held over Chime and the invite should be sent no less than
+  a week in advance. This is to give the attendees a chance to prepare if they
+  so desire. Include the agenda in the invite:
 
   - Champion to introduce the people and re-iterate the goal of the review.
   - 10-15 minutes individual reading of the module README.
   - Participants raise concerns.
-  - Champion will do a quick overview of external APIs not covered by the README.
+  - Champion will do a quick overview of external APIs not covered by the
+    README.
   - Participants raise concerns.
-  - Champion will address any asynchronous feedback provided in the graduation issue.
+  - Champion will address any asynchronous feedback provided in the graduation
+    issue.
   - Participants raise concerns.
   - Champion will address any high traction open `guidance` issues.
   - Participants raise concerns.
   - Champion will summarize and recap all action items.
-  - **Participants decide if the module stays in *Developer Preview* or if its ready to move to *Stable*.
-    In addition, decide which action items need to be completed before graduation.**
-      > Note that Deciding to re-group asynchronously to allow some time to think about the concerns is also valid.
-      > In any case, it is the champion's responsibility to push this forward and bring it to a close.
+  - **Participants decide if the module stays in _Developer Preview_ or if its
+    ready to move to _Stable_. In addition, decide which action items need to be
+    completed before graduation.**
+    > Note that Deciding to re-group asynchronously to allow some time to think
+    > about the concerns is also valid. In any case, it is the champion's
+    > responsibility to push this forward and bring it to a close.
 
-  Champion will update the graduation issue checklist with relevant action items.
+  Champion will update the graduation issue checklist with relevant action
+  items.
 
   The invite should also include the following "disclaimer":
 
-  *As you prepare for this session, try to focus on the most critical/obvious API and security issues.
-  We strive to make the session as minimal as possible, so keep asking yourself: Is this really a graduation blocker?*
+  _As you prepare for this session, try to focus on the most critical/obvious
+  API and security issues. We strive to make the session as minimal as possible,
+  so keep asking yourself: Is this really a graduation blocker?_
 
 - **Complete Graduation Issues**
 
-  All issues that were deemed required for graduation in the API review are completed by the champion.
+  All issues that were deemed required for graduation in the API review are
+  completed by the champion.
 
 - **Create and Merge Graduation PR**
 
-  Once all required issues for graduation are complete, champion will create a PR that contains:
+  Once all required issues for graduation are complete, champion will create a
+  PR that contains:
 
   - Change stability in `package.json` from `experimental` to `stable`.
   - Remove all `@experimental` annotations.
-  - Remove *Developer Preview* disclaimer from README.
+  - Remove _Developer Preview_ disclaimer from README.
 
-  This indicates that the high-level constructs are production ready and adhere to the [SemVer specification](https://semver.org/).
+  This indicates that the high-level constructs are production ready and adhere
+  to the [SemVer specification](https://semver.org/).
 
-  The PR should be linked to the graduation issue and will close it once it merged.
+  The PR should be linked to the graduation issue and will close it once it
+  merged.
 
 - **Update Roadmap** - Move to the CDK roadmap “shipped” column
 
@@ -284,58 +349,77 @@ Update the module tracking issue with a link to this issue so that the community
 
 ### Ongoing activities
 
-- **Observe** - monitor module utilization and GitHub issues filed against the stable module
+- **Observe** - monitor module utilization and GitHub issues filed against the
+  stable module
 
 ## Construct prioritization tenets
 
-We use the following tenets to prioritize which AWS-CDK Construct Library modules to work on next:
+We use the following tenets to prioritize which AWS-CDK Construct Library
+modules to work on next:
 
-- _"Favor community contributions above all"_ - customers who take the time to contribute code to the AWS CDK get
-  preferential treatment above all else
-- _“Don’t experiment on too much at once”_ - no more than 20% of the AWS Construct Library will be experimental at any
-  given time. For reference, on 1/1/2020, the construct library module breakdown = 32% (39/123) Stable, 18% (22/123)
-  Experimental, 50% (62/123) CFN-only.
-- _“Focus on what customers ask for”_ - prioritize modules based on number of feature requests and +1’s on GitHub.
-- _“Finish what we’ve started”_ - prioritize modules that already have L2 constructs but are still experimental.
-- _“Do the most difficult work first”_ - prioritize modules that have a large and/or complex API surface area that we
-  know will take significant effort. [Appendix B](#appendix-b:-module-complexity-t-shirt-sizes) proposes “T-shirt”sizes
-  for each module in the construct library to identify work that falls into this category, and module owners are
-  responsible for estimate this effort.
-- _“Strategic alignment”_ - prioritize based on AWS / department / team goals. We will use our weekly, monthly, and
-  quarterly planning meetings to identify modules that meet this criteria. For example, in 2019, there was a Developer
-  Tools strategic initiative to enable containerized and serverless application workloads which informed our decisions
-  on what construct library modules to prioritize for CDKs GA launch.
-- _“Focus on what customers are actually using”_ - prioritize constructs that only have CFN resources, but are highly
-  utilized (according to analytics data). A highly used, CFN-only construct library modules might indicate that the
-  low-level resources are sufficient for customer’s primary use cases, and high-level abstractions are not necessary.
+- _"Favor community contributions above all"_ - customers who take the time to
+  contribute code to the AWS CDK get preferential treatment above all else
+- _“Don’t experiment on too much at once”_ - no more than 20% of the AWS
+  Construct Library will be experimental at any given time. For reference, on
+  1/1/2020, the construct library module breakdown = 32% (39/123) Stable, 18%
+  (22/123) Experimental, 50% (62/123) CFN-only.
+- _“Focus on what customers ask for”_ - prioritize modules based on number of
+  feature requests and +1’s on GitHub.
+- _“Finish what we’ve started”_ - prioritize modules that already have L2
+  constructs but are still experimental.
+- _“Do the most difficult work first”_ - prioritize modules that have a large
+  and/or complex API surface area that we know will take significant effort.
+  [Appendix B](#appendix-b:-module-complexity-t-shirt-sizes) proposes
+  “T-shirt”sizes for each module in the construct library to identify work that
+  falls into this category, and module owners are responsible for estimate this
+  effort.
+- _“Strategic alignment”_ - prioritize based on AWS / department / team goals.
+  We will use our weekly, monthly, and quarterly planning meetings to identify
+  modules that meet this criteria. For example, in 2019, there was a Developer
+  Tools strategic initiative to enable containerized and serverless application
+  workloads which informed our decisions on what construct library modules to
+  prioritize for CDKs GA launch.
+- _“Focus on what customers are actually using”_ - prioritize constructs that
+  only have CFN resources, but are highly utilized (according to analytics
+  data). A highly used, CFN-only construct library modules might indicate that
+  the low-level resources are sufficient for customer’s primary use cases, and
+  high-level abstractions are not necessary.
 
 ## Appendix A: GitHub artifacts
 
 This diagram illustrates the different GitHub artifacts and their relationships.
 
-- **Module Tracking Issue** - Module tracking issues represent an entire AWS service and summarize the planned scope of
-  work for a specific construct library module. This is the issue we want customers to +1 to help us prioritize work on
-  modules that are currently CFN-only, and is the issue we will place on the public roadmap to communicate work in
-  progress.
-- **Module Design RFC [optional]** - Request for comment documents will be created for large / complex designs that
-  require explanation and robust discussion. RFCs are stored in a separate GitHub repo, and the top-level tracking issue
-  should include link to the RFC.
-- **Feature Requests** - We have a backlog of feature requests tagged for each module. When we decide to include a
-  customer feature request in the scope of work, links to these issues are added to the module’s tracking issue.
-  Customers can +1 and comment on individual feature requests, just like they can +1 and comment on the top-level
-  tracking issue. _Note_: it is not a requirement to address all feature requests when maturing a construct library.
-- **Bugs** - Similar to feature requests, we have a backlog of P1 and P2 bugs tagged for each module. When we decide to
-  fix specific, known bugs as part of maturing a construct, links to these issues are added to the module’s tracking
+- **Module Tracking Issue** - Module tracking issues represent an entire AWS
+  service and summarize the planned scope of work for a specific construct
+  library module. This is the issue we want customers to +1 to help us
+  prioritize work on modules that are currently CFN-only, and is the issue we
+  will place on the public roadmap to communicate work in progress.
+- **Module Design RFC [optional]** - Request for comment documents will be
+  created for large / complex designs that require explanation and robust
+  discussion. RFCs are stored in a separate GitHub repo, and the top-level
+  tracking issue should include link to the RFC.
+- **Feature Requests** - We have a backlog of feature requests tagged for each
+  module. When we decide to include a customer feature request in the scope of
+  work, links to these issues are added to the module’s tracking issue.
+  Customers can +1 and comment on individual feature requests, just like they
+  can +1 and comment on the top-level tracking issue. _Note_: it is not a
+  requirement to address all feature requests when maturing a construct library.
+- **Bugs** - Similar to feature requests, we have a backlog of P1 and P2 bugs
+  tagged for each module. When we decide to fix specific, known bugs as part of
+  maturing a construct, links to these issues are added to the module’s tracking
   issue.
-  > **Note**: It is not a requirement to address all P1 or P2 bugs when maturing a construct library.
+  > **Note**: It is not a requirement to address all P1 or P2 bugs when maturing
+  > a construct library.
 
 ![GitHubArtifactsPNG](../images/GitHubArtifacts.png)
 
 ## Appendix B: Module complexity T-shirt sizes
 
-One of our tenets is to prioritize work on large/complex modules to ensure we make progress on high-level abstractions
-for services that we cannot complete in a single quarter. Measured in the amount of time required to graduate a module
-from CFN-only to a Developer Preview release candidate, the proposed sizing scale is:
+One of our tenets is to prioritize work on large/complex modules to ensure we
+make progress on high-level abstractions for services that we cannot complete in
+a single quarter. Measured in the amount of time required to graduate a module
+from CFN-only to a Developer Preview release candidate, the proposed sizing
+scale is:
 
 - **Small**: 1 month or less
 - **Medium**: 2-3 months
@@ -344,7 +428,8 @@ from CFN-only to a Developer Preview release candidate, the proposed sizing scal
 
 ## Appendix C: Action Items
 
-- [ ] automate the creation of new tracking issues when new CFN-only modules are autogenerated
+- [ ] automate the creation of new tracking issues when new CFN-only modules are
+      autogenerated
 - [ ] create an example tracking issue for reference
 - [ ] update `package.json` for all CFN-only modules to 'stable'
 - [ ] update `package.json` for all modules in 'developer preview'

--- a/text/0171-cloudfront-redesign.md
+++ b/text/0171-cloudfront-redesign.md
@@ -1,7 +1,7 @@
 ---
 feature name: CloudFront redesign
 start date: 2020-06-15
-rfc pr:
+? rfc pr
 related issue: https://github.com/aws/aws-cdk-rfcs/issues/171
 ---
 
@@ -9,33 +9,37 @@ related issue: https://github.com/aws/aws-cdk-rfcs/issues/171
 
 Proposal to redesign the @aws-cdk/aws-cloudfront module.
 
-The current module does not adhere to the best practice naming conventions or ease-of-use patterns
-that are present in the other CDK modules. A redesign of the API will allow for friendly, easier
-access to common patterns and usages.
+The current module does not adhere to the best practice naming conventions or
+ease-of-use patterns that are present in the other CDK modules. A redesign of
+the API will allow for friendly, easier access to common patterns and usages.
 
-This RFC does not attempt to lay out the entire API; rather, it focuses on a complete re-write of
-the module README with a focus on the most common use cases and how they work with the new design.
-More detailed designs and incremental API improvements will be tracked as part of GitHub Project Board
-once the RFC is approved.
+This RFC does not attempt to lay out the entire API; rather, it focuses on a
+complete re-write of the module README with a focus on the most common use cases
+and how they work with the new design. More detailed designs and incremental API
+improvements will be tracked as part of GitHub Project Board once the RFC is
+approved.
 
 ---
 
 # README
 
-Amazon CloudFront is a web service that speeds up distribution of your static and dynamic web content, such as .html, .css, .js, and image files, to
-your users. CloudFront delivers your content through a worldwide network of data centers called edge locations. When a user requests content that
-you're serving with CloudFront, the user is routed to the edge location that provides the lowest latency, so that content is delivered with the best
-possible performance.
+Amazon CloudFront is a web service that speeds up distribution of your static
+and dynamic web content, such as .html, .css, .js, and image files, to your
+users. CloudFront delivers your content through a worldwide network of data
+centers called edge locations. When a user requests content that you're serving
+with CloudFront, the user is routed to the edge location that provides the
+lowest latency, so that content is delivered with the best possible performance.
 
 ## Creating a distribution
 
-CloudFront distributions deliver your content from one or more origins; an origin is the location where you store the original version of your
-content. Origins can be created from S3 buckets or a custom origin (HTTP server).
+CloudFront distributions deliver your content from one or more origins; an
+origin is the location where you store the original version of your content.
+Origins can be created from S3 buckets or a custom origin (HTTP server).
 
 ### From an S3 Bucket
 
-An S3 bucket can be added as an origin. If the bucket is configured as a website endpoint, the distribution can use S3 redirects and S3 custom error
-documents.
+An S3 bucket can be added as an origin. If the bucket is configured as a website
+endpoint, the distribution can use S3 redirects and S3 custom error documents.
 
 ```ts
 import * as cloudfront from '@aws-cdk/aws-cloudfront';
@@ -61,12 +65,15 @@ const myBucket = new s3.Bucket(...);
 cloudfront.Distribution.forWebsiteBucket(this, 'myDist', myBucket);
 ```
 
-Both of the S3 Origin options will automatically create an origin access identity and grant it access to the underlying bucket. This can be used in
-conjunction with a bucket that is not public to require that your users access your content using CloudFront URLs and not S3 URLs directly.
+Both of the S3 Origin options will automatically create an origin access
+identity and grant it access to the underlying bucket. This can be used in
+conjunction with a bucket that is not public to require that your users access
+your content using CloudFront URLs and not S3 URLs directly.
 
 ### From an HTTP endpoint
 
-Origins can also be created from other resources (e.g., load balancers, API gateways), or from any accessible HTTP server.
+Origins can also be created from other resources (e.g., load balancers, API
+gateways), or from any accessible HTTP server.
 
 ```ts
 // Creates a distribution for an application load balancer.
@@ -86,19 +93,24 @@ new cloudfront.Distribution(this, 'myDist', {
 
 ## Domain Names and Certificates
 
-When you create a distribution, CloudFront returns a domain name for the distribution, for example: `d111111abcdef8.cloudfront.net`. If you want to
-use your own domain name, such as `www.example.com`, you can add an alternate domain name to your distribution.
+When you create a distribution, CloudFront returns a domain name for the
+distribution, for example: `d111111abcdef8.cloudfront.net`. If you want to use
+your own domain name, such as `www.example.com`, you can add an alternate domain
+name to your distribution.
 
 ```ts
 new cloudfront.Distribution(this, 'myDist', {
   origin: cloudfront.Origin.fromBucket(myBucket),
   aliases: ['www.example.com'],
-})
+});
 ```
 
-CloudFront distributions use a default certificate (`*.cloudfront.net`) to support HTTPS by default. If you want to support HTTPS with your own domain
-name, you must associate a certificate with your distribution that contains your domain name. The certificate must be present in the AWS Certificate
-Manager (ACM) service in the US East (N. Virginia) region; the certificate may either be created by ACM, or created elsewhere and imported into ACM.
+CloudFront distributions use a default certificate (`*.cloudfront.net`) to
+support HTTPS by default. If you want to support HTTPS with your own domain
+name, you must associate a certificate with your distribution that contains your
+domain name. The certificate must be present in the AWS Certificate Manager
+(ACM) service in the US East (N. Virginia) region; the certificate may either be
+created by ACM, or created elsewhere and imported into ACM.
 
 ```ts
 const myCertificate = new certmgr.DnsValidatedCertificate(this, 'mySiteCert', {
@@ -111,16 +123,20 @@ new cloudfront.Distribution(this, 'myDist', {
 });
 ```
 
-Note that in the above example the aliases are inferred from the certificate and do not need to be explicitly provided.
+Note that in the above example the aliases are inferred from the certificate and
+do not need to be explicitly provided.
 
 ## Behaviors
 
-Each distribution has a default behavior which applies to all requests to that distribution; additional behaviors may be specified for a
-given URL path pattern. Behaviors allow routing with multiple origins, controlling which HTTP methods to support, whether to require users to
-use HTTPS, and what query strings or cookies to forward to your origin, among others.
+Each distribution has a default behavior which applies to all requests to that
+distribution; additional behaviors may be specified for a given URL path
+pattern. Behaviors allow routing with multiple origins, controlling which HTTP
+methods to support, whether to require users to use HTTPS, and what query
+strings or cookies to forward to your origin, among others.
 
-The properties of the default behavior can be adjusted as part of the distribution creation. The following example shows configuring the HTTP
-methods and viewer protocol policy of the cache.
+The properties of the default behavior can be adjusted as part of the
+distribution creation. The following example shows configuring the HTTP methods
+and viewer protocol policy of the cache.
 
 ```ts
 const myWebDistribution = new cloudfront.Distribution(this, 'myDist', {
@@ -131,9 +147,11 @@ const myWebDistribution = new cloudfront.Distribution(this, 'myDist', {
 });
 ```
 
-Additional cache behaviors can be specified at creation, or added to the origin(s) after the initial creation. These additional cache behaviors enable
-customization for a specific set of resources based on a URL path pattern. For example, we can add a behavior to `myWebDistribution` to override the
-default time-to-live (TTL) for all of the images.
+Additional cache behaviors can be specified at creation, or added to the
+origin(s) after the initial creation. These additional cache behaviors enable
+customization for a specific set of resources based on a URL path pattern. For
+example, we can add a behavior to `myWebDistribution` to override the default
+time-to-live (TTL) for all of the images.
 
 ```ts
 myWebDistribution.origin.addBehavior('/images/*.jpg', {
@@ -144,9 +162,11 @@ myWebDistribution.origin.addBehavior('/images/*.jpg', {
 
 ## Multiple Origins
 
-A distribution may have multiple origins in addition to the default origin; each additional origin must have (at least) one behavior to route requests
-to that origin. A common pattern might be to serve all static assets from an S3 bucket, but all dynamic content served from a web server. The
-following example shows how such a setup might be created:
+A distribution may have multiple origins in addition to the default origin; each
+additional origin must have (at least) one behavior to route requests to that
+origin. A common pattern might be to serve all static assets from an S3 bucket,
+but all dynamic content served from a web server. The following example shows
+how such a setup might be created:
 
 ```ts
 const myWebsiteBucket = new s3.Bucket(...);
@@ -164,10 +184,12 @@ const myMultiOriginDistribution = new cloudfront.Distribution(this, 'myDist', {
 
 ## Origin Groups
 
-You can specify an origin group for your CloudFront origin if, for example, you want to configure origin failover for scenarios when you need high
-availability. Use origin failover to designate a primary origin for CloudFront plus a second origin that CloudFront automatically switches to when the
-primary origin returns specific HTTP status code failure responses. An origin group can be created and specified as the primary (or additional) origin
-for the distribution.
+You can specify an origin group for your CloudFront origin if, for example, you
+want to configure origin failover for scenarios when you need high availability.
+Use origin failover to designate a primary origin for CloudFront plus a second
+origin that CloudFront automatically switches to when the primary origin returns
+specific HTTP status code failure responses. An origin group can be created and
+specified as the primary (or additional) origin for the distribution.
 
 ```ts
 const myOriginGroup = cloudfront.Origin.fromOriginGroup({
@@ -178,16 +200,22 @@ const myOriginGroup = cloudfront.Origin.fromOriginGroup({
 new cloudfront.Distribution(this, 'myDist', { origin: myOriginGroup });
 ```
 
-The above will create both origins and a single origin group with the load balancer origin falling back to the S3 bucket in case of 500 or 503 errors.
+The above will create both origins and a single origin group with the load
+balancer origin falling back to the S3 bucket in case of 500 or 503 errors.
 
 ## Lambda@Edge
 
-Lambda@Edge is an extension of AWS Lambda, a compute service that lets you execute functions that customize the content that CloudFront delivers. You
-can author Node.js or Python functions in the US East (N. Virginia) region, and then execute them in AWS locations globally that are closer to the
-viewer, without provisioning or managing servers. Lambda@Edge functions are associated with a specific behavior and event type. Lambda@Edge can be
-used rewrite URLs, alter responses based on headers or cookies, or authorize requests based on headers or authorization tokens.
+Lambda@Edge is an extension of AWS Lambda, a compute service that lets you
+execute functions that customize the content that CloudFront delivers. You can
+author Node.js or Python functions in the US East (N. Virginia) region, and then
+execute them in AWS locations globally that are closer to the viewer, without
+provisioning or managing servers. Lambda@Edge functions are associated with a
+specific behavior and event type. Lambda@Edge can be used rewrite URLs, alter
+responses based on headers or cookies, or authorize requests based on headers or
+authorization tokens.
 
-The following shows a Lambda@Edge function added to the default behavior and triggered on every request.
+The following shows a Lambda@Edge function added to the default behavior and
+triggered on every request.
 
 ```ts
 const myFunc = new lambda.Function(...);
@@ -201,8 +229,8 @@ new cloudfront.Distribution(this, 'myDist', {
 });
 ```
 
-Lambda@Edge functions can also be associated with additional behaviors, either at behavior creation (associated with the origin) or after behavior
-creation.
+Lambda@Edge functions can also be associated with additional behaviors, either
+at behavior creation (associated with the origin) or after behavior creation.
 
 ```ts
 // Assigning at behavior creation.
@@ -227,66 +255,101 @@ myImagesBehavior.addEdgeFunction({
 
 # Motivation
 
-The existing aws-cloudfront module doesn't adhere to standard naming convention, lacks convenience methods for more easily interacting with
-distributions, origins, and behaviors, and has been in an "experimental" state for years. This proposal aims to bring a friendlier, more ergonomic
-interface to the module, and advance the module to a GA-ready state.
+The existing aws-cloudfront module doesn't adhere to standard naming convention,
+lacks convenience methods for more easily interacting with distributions,
+origins, and behaviors, and has been in an "experimental" state for years. This
+proposal aims to bring a friendlier, more ergonomic interface to the module, and
+advance the module to a GA-ready state.
 
 # Design Summary
 
-The approach will create a new top-level Construct (`Distribution`) to replace the existing `CloudFrontWebDistribution`, as well as new constructs to
-represent the other logical resources for a distribution (i.e., `Origin`, `Behavior`). The new construct is optimized for the most common use cases of
-creating a distribution with a single origin and behavior. The new L2s will be created in the same aws-cloudfront module and no changes will be made
-to the existing L2s to preserve the existing experience. Unlike the existing L2, the new L2s will feature a variety of convenience methods (e.g.,
-`addBehavior`) to aid in the creation of the distribution, and provide several out-of-the-box defaults for building distributions off of other
-resources (e.g., buckets, load balanced services).
+The approach will create a new top-level Construct (`Distribution`) to replace
+the existing `CloudFrontWebDistribution`, as well as new constructs to represent
+the other logical resources for a distribution (i.e., `Origin`, `Behavior`). The
+new construct is optimized for the most common use cases of creating a
+distribution with a single origin and behavior. The new L2s will be created in
+the same aws-cloudfront module and no changes will be made to the existing L2s
+to preserve the existing experience. Unlike the existing L2, the new L2s will
+feature a variety of convenience methods (e.g., `addBehavior`) to aid in the
+creation of the distribution, and provide several out-of-the-box defaults for
+building distributions off of other resources (e.g., buckets, load balanced
+services).
 
 # Detailed Design
 
-The design creates one new resource (`Distribution`) and two new classes (`Origin` and `Behavior`) to replace the current
-`CloudFrontWebDistribution` construct. Each of these new classes comes with helper methods (e.g., `addBehavior`) to make assembling more complex
-distributions easier, as well as factory constructors to make it easier to build common Origin and Behavior patterns (e.g., `Origin.fromBucket`).
+The design creates one new resource (`Distribution`) and two new classes
+(`Origin` and `Behavior`) to replace the current `CloudFrontWebDistribution`
+construct. Each of these new classes comes with helper methods (e.g.,
+`addBehavior`) to make assembling more complex distributions easier, as well as
+factory constructors to make it easier to build common Origin and Behavior
+patterns (e.g., `Origin.fromBucket`).
 
 The following is an incomplete, but representative, listing of the API:
 
 ```ts
 class Distribution extends BaseDistribution {
-  static fromDistributionAttributes(scope: Construct, id: string, attributes: DistributionAttributes): IDistribution;
+  static fromDistributionAttributes(
+    scope: Construct,
+    id: string,
+    attributes: DistributionAttributes,
+  ): IDistribution;
 
   static forBucket(scope: Construct, id: string, bucket: IBucket): Distribution;
-  static forWebsiteBucket(scope: Construct, id: string, bucket: IBucket): Distribution;
+  static forWebsiteBucket(
+    scope: Construct,
+    id: string,
+    bucket: IBucket,
+  ): Distribution;
 
   constructor(scope: Construct, id: string, props: DistributionProps) {}
 
-  addOrigin(options: OriginOptions): Origin
+  addOrigin(options: OriginOptions): Origin;
 }
 
 class Origin {
-  static fromBucket(bucket: s3.IBucket, behaviorOptions?: BehaviorProps): Origin
-  static fromWebsiteBucket(bucket: s3.IBucket, behaviorOptions?: BehaviorProps): Origin
-  static fromLoadBalancerV2(loadBalancer: elbv2.ApplicationLoadBalancer, behaviorOptions?: BehaviorProps): Origin
-  static fromHttpServer(options: ServerOriginOptions, behaviorOptions?: BehaviorProps): Origin
-  static fromOriginGroup(options: OriginGroupOptions): Origin
+  static fromBucket(
+    bucket: s3.IBucket,
+    behaviorOptions?: BehaviorProps,
+  ): Origin;
+  static fromWebsiteBucket(
+    bucket: s3.IBucket,
+    behaviorOptions?: BehaviorProps,
+  ): Origin;
+  static fromLoadBalancerV2(
+    loadBalancer: elbv2.ApplicationLoadBalancer,
+    behaviorOptions?: BehaviorProps,
+  ): Origin;
+  static fromHttpServer(
+    options: ServerOriginOptions,
+    behaviorOptions?: BehaviorProps,
+  ): Origin;
+  static fromOriginGroup(options: OriginGroupOptions): Origin;
 
   constructor(props: OriginProps) {}
 
-  addBehavior(pathPattern: string, options: BehaviorOptions): Behavior
+  addBehavior(pathPattern: string, options: BehaviorOptions): Behavior;
 }
 
 class Behavior {
   constructor(props: BehaviorProps) {}
 
-  addEdgeFunction(options: EdgeFunctionOptions): EdgeFunction
+  addEdgeFunction(options: EdgeFunctionOptions): EdgeFunction;
 }
 ```
 
 ## Nested structure and relationships
 
-The `Distribution` has one top-level origin and behavior, which aligns to how the vast majority of customers use CloudFront today (based on public
-CDK examples). Customers can add additional origins (and origin groups) and behaviors, which are modeled as `additionalOrigins` and
-`additionalBehaviors`, respectively. Each origin may have multiple behaviors associated with it, so the relationship is modeled such that behaviors
-are added to origins. However, an authoritative list of behaviors is kept on the distribution to preserve ordering. This is done similarly to how
-ECS clusters keep track of Fargate profiles as they are created and associated with the cluster. In the below example, the '/api/\*' behavior for
-the load balancer origin will be ordered first, then the '/api/errors/\*' behavior on the bucket.
+The `Distribution` has one top-level origin and behavior, which aligns to how
+the vast majority of customers use CloudFront today (based on public CDK
+examples). Customers can add additional origins (and origin groups) and
+behaviors, which are modeled as `additionalOrigins` and `additionalBehaviors`,
+respectively. Each origin may have multiple behaviors associated with it, so the
+relationship is modeled such that behaviors are added to origins. However, an
+authoritative list of behaviors is kept on the distribution to preserve
+ordering. This is done similarly to how ECS clusters keep track of Fargate
+profiles as they are created and associated with the cluster. In the below
+example, the '/api/\*' behavior for the load balancer origin will be ordered
+first, then the '/api/errors/\*' behavior on the bucket.
 
 ```ts
 const myWebsiteBucket = new s3.Bucket(...);
@@ -303,45 +366,62 @@ const myMultiOriginDistribution = new cloudfront.Distribution(this, 'myDist', {
 myMultiOriginDistribution.origin.addBehavior('/api/errors/*', ...);
 ```
 
-This approach was chosen as the simplest pattern to work with for the majority of customers that don't add multiple origins and behaviors, while
-still giving those power users control over behavior ordering, albeit implicitly. See the Rationale and Alternatives section for a discussion of
-other ways this was considered.
+This approach was chosen as the simplest pattern to work with for the majority
+of customers that don't add multiple origins and behaviors, while still giving
+those power users control over behavior ordering, albeit implicitly. See the
+Rationale and Alternatives section for a discussion of other ways this was
+considered.
 
-**Implementation Note:** The relationships as-is are modeled with one-way connections; Distributions know about Origins, but Origins have no
-references to Distributions, for example. This design makes the initial creation much simpler for users, but makes having a per-Distribution
-ordered list of Behaviors impossible. To correct this, the Origin will need some form of reference to the Distribution, either at creation or
-when being associated with the Distribution. The current (inelegant) proposal is for the Origin to expose a method (`_attachDistribution`) which
-is called by the Distribution to create the relationship. Feedback on this approach (or more elegent proposals) are welcome.
+**Implementation Note:** The relationships as-is are modeled with one-way
+connections; Distributions know about Origins, but Origins have no references to
+Distributions, for example. This design makes the initial creation much simpler
+for users, but makes having a per-Distribution ordered list of Behaviors
+impossible. To correct this, the Origin will need some form of reference to the
+Distribution, either at creation or when being associated with the Distribution.
+The current (inelegant) proposal is for the Origin to expose a method
+(`_attachDistribution`) which is called by the Distribution to create the
+relationship. Feedback on this approach (or more elegent proposals) are welcome.
 
 ## Interaction with other L2s
 
-The existing @aws-cdk/aws-cloudfront module is used in three other modules of the CDK: (1) aws-route53-patterns, (2) aws-route53-targets, and
-(3) aws-s3-deployment.
+The existing @aws-cdk/aws-cloudfront module is used in three other modules of
+the CDK: (1) aws-route53-patterns, (2) aws-route53-targets, and (3)
+aws-s3-deployment.
 
-1. In aws-route53-patterns, the CloudFrontWebDistribution is used internally to the HttpsRedirect class; no CloudFront
-properties or classes are exposed to the consumer. This usage can be swapped out when the new L2s are ready without impact to customers.
-2. In aws-route53-targets, the CloudFrontTarget constructor takes a CloudFrontWebDistribution as the sole parameter. This usage could actually
-be replaced with an IDistribution, and then work for both Distribution and CloudFrontWebDistribution. I _believe_ this is a backwards-compatible
-change; please correct me if I'm wrong.
-3. In aws-s3-deployment, BucketDeploymentProps has an optional IDistribution member, which does not need to be changed.
+1. In aws-route53-patterns, the CloudFrontWebDistribution is used internally to
+   the HttpsRedirect class; no CloudFront properties or classes are exposed to
+   the consumer. This usage can be swapped out when the new L2s are ready
+   without impact to customers.
+2. In aws-route53-targets, the CloudFrontTarget constructor takes a
+   CloudFrontWebDistribution as the sole parameter. This usage could actually be
+   replaced with an IDistribution, and then work for both Distribution and
+   CloudFrontWebDistribution. I _believe_ this is a backwards-compatible change;
+   please correct me if I'm wrong.
+3. In aws-s3-deployment, BucketDeploymentProps has an optional IDistribution
+   member, which does not need to be changed.
 
 ## Comparison with the existing API
 
-The primary drawback of this work is that an existing CloudFront L2 already exists and is in wide use. To justify the creation of a new API, this
-section provides examples of what the user experience of common (and some uncommon) use cases will be before and after the redesign.
+The primary drawback of this work is that an existing CloudFront L2 already
+exists and is in wide use. To justify the creation of a new API, this section
+provides examples of what the user experience of common (and some uncommon) use
+cases will be before and after the redesign.
 
 ### Use Case #1 - S3 bucket origin
 
-The simplest use case is to have a single S3 bucket origin, and no customized behaviors.
+The simplest use case is to have a single S3 bucket origin, and no customized
+behaviors.
 
 **Before:**
 
 ```ts
 new CloudFrontWebDistribution(this, 'MyDistribution', {
-  originConfigs: [{
-    s3OriginSource: { s3BucketSource: sourceBucket },
-    behaviors : [ { isDefaultBehavior: true }],
-  }]
+  originConfigs: [
+    {
+      s3OriginSource: { s3BucketSource: sourceBucket },
+      behaviors: [{ isDefaultBehavior: true }],
+    },
+  ],
 });
 ```
 
@@ -355,22 +435,25 @@ new cloudfront.Distribution(this, 'MyDistribution', {
 
 ### Use Case #2 - S3 bucket origin with certificate and custom behavior
 
-This example keeps the same bucket, but adds one custom behavior and a certificate.
+This example keeps the same bucket, but adds one custom behavior and a
+certificate.
 
 **Before:**
 
 ```ts
 new CloudFrontWebDistribution(this, 'MyDistribution', {
-  originConfigs: [{
-    s3OriginSource: { s3BucketSource: sourceBucket },
-    behaviors : [
-      { isDefaultBehavior: true },
-      {
-        pathPattern: 'images/*',
-        defaultTtl: cdk.Duration.days(7),
-      }
-    ]
-  }],
+  originConfigs: [
+    {
+      s3OriginSource: { s3BucketSource: sourceBucket },
+      behaviors: [
+        { isDefaultBehavior: true },
+        {
+          pathPattern: 'images/*',
+          defaultTtl: cdk.Duration.days(7),
+        },
+      ],
+    },
+  ],
   viewerCertificate: ViewerCertificate.fromAcmCertificate(myCertificate),
 });
 ```
@@ -387,7 +470,8 @@ dist.origin.addBehavior('images/*', { defaultTtl: cdk.Duration.days(7) });
 
 ### Use Case #3 - Multi-origin, multi-behavior distribution with a Lambda@Edge function
 
-Both S3 and LoadBalancedFargateService origins, custom behaviors, and a Lambda function to top it all off.
+Both S3 and LoadBalancedFargateService origins, custom behaviors, and a Lambda
+function to top it all off.
 
 **Before:**
 
@@ -399,22 +483,30 @@ new CloudFrontWebDistribution(this, 'dist', {
         domainName: lbFargateService.loadBalancer.loadBalancerDnsName,
         protocolPolicy: OriginProtocolPolicy.HTTPS_ONLY,
       },
-      behaviors: [{
-        isDefaultBehavior: true,
-        allowedMethods: CloudFrontAllowedMethods.ALL,
-        forwardedValues: { queryString: true },
-        lambdaFunctionAssociations: [{
-          lambdaFunction: myFunctionVersion,
-          eventType: LambdaEdgeEventType.ORIGIN_RESPONSE,
-        }]
-      }]
+      behaviors: [
+        {
+          isDefaultBehavior: true,
+          allowedMethods: CloudFrontAllowedMethods.ALL,
+          forwardedValues: { queryString: true },
+          lambdaFunctionAssociations: [
+            {
+              lambdaFunction: myFunctionVersion,
+              eventType: LambdaEdgeEventType.ORIGIN_RESPONSE,
+            },
+          ],
+        },
+      ],
     },
     {
       s3OriginSource: {
         s3BucketSource: sourceBucket,
-        originAccessIdentity: OriginAccessIdentity.fromOriginAccessIdentityName(this, 'oai', 'distOAI'),
+        originAccessIdentity: OriginAccessIdentity.fromOriginAccessIdentityName(
+          this,
+          'oai',
+          'distOAI',
+        ),
       },
-      behaviors: [ { pathPattern: 'static/*' } ],
+      behaviors: [{ pathPattern: 'static/*' }],
     },
   ],
 });
@@ -427,61 +519,86 @@ const dist = new cloudfront.Distribution(this, 'MyDistribution', {
   origin: cloudfront.Origin.fromLoadBalancerV2(lbFargateService.loadBalancer, {
     allowedMethods: AllowedMethods.ALL,
     forwardQueryString: true,
-    edgeFunctions: [{
-      function: myFunctionVersion,
-      eventType: EventType.ORIGIN_RESPONSE,
-    }],
+    edgeFunctions: [
+      {
+        function: myFunctionVersion,
+        eventType: EventType.ORIGIN_RESPONSE,
+      },
+    ],
   }),
 });
-dist.addOrigin(cloudfront.Origin.fromBucket(sourceBucket), { pathPattern: 'static/*' });
+dist.addOrigin(cloudfront.Origin.fromBucket(sourceBucket), {
+  pathPattern: 'static/*',
+});
 ```
 
 # Drawbacks
 
-The primary drawback to this work is one of adoption. The aws-cloudfront module is one of the oldest in the CDK, and is used by many customers.
-These changes won't break any of the existing customers, but all existing customers would need to rewrite their CloudFront constructs to take
-advantage of the functionality and ease-of-use benefits of the new L2s. For building an entirely new set of L2s to be worth the return on investment,
-the improvements to functionality and ergonomics needs to be substantial. Feedback is welcome on how to best capitalize on this opportunity and make
-the friendliest interface possible.
+The primary drawback to this work is one of adoption. The aws-cloudfront module
+is one of the oldest in the CDK, and is used by many customers. These changes
+won't break any of the existing customers, but all existing customers would need
+to rewrite their CloudFront constructs to take advantage of the functionality
+and ease-of-use benefits of the new L2s. For building an entirely new set of L2s
+to be worth the return on investment, the improvements to functionality and
+ergonomics needs to be substantial. Feedback is welcome on how to best
+capitalize on this opportunity and make the friendliest interface possible.
 
 # Rationale and Alternatives
 
-This RFC aims to take one of the older modules in the CDK and update it to the current set of design standards. By introducing secondary resource
-creation methods, factories for common L2-based origins, and flattening some of the top-level nested properties, we can offer an easier-to-use
-experience.
+This RFC aims to take one of the older modules in the CDK and update it to the
+current set of design standards. By introducing secondary resource creation
+methods, factories for common L2-based origins, and flattening some of the
+top-level nested properties, we can offer an easier-to-use experience.
 
-The interface aims to make it easiest for the 90%+ use cases of having a single origin based on an S3 bucket (or other CDK construct), with a single
-default behavior, optionally slightly customized; it accomplishes this by exposing a single top-level `origin` and `behavior` and making us of
-factory methods to construct origins from buckets, load balancers, and other common origins. Beyond that straightforward use-case, the decision was
-made to represent the behaviors as members of origins, as each behavior must be associated with an origin. This introduces one area of cognitive
-complexity in terms of behavior ordering.
+The interface aims to make it easiest for the 90%+ use cases of having a single
+origin based on an S3 bucket (or other CDK construct), with a single default
+behavior, optionally slightly customized; it accomplishes this by exposing a
+single top-level `origin` and `behavior` and making us of factory methods to
+construct origins from buckets, load balancers, and other common origins. Beyond
+that straightforward use-case, the decision was made to represent the behaviors
+as members of origins, as each behavior must be associated with an origin. This
+introduces one area of cognitive complexity in terms of behavior ordering.
 
-Behaviors are ordered and precedence is used to determine how to route requests to origin(s). For example, origin #1 could have custom behaviors with
-path patterns of 'images/\*.jpg' and '\*.gif', and origin #2 could have a behavior on 'images/\*'. Depending on the ordering, a request for
-'images/foo.gif' may either be routed to origin #1 or #2. The approach taken ties behavior precedence to order of creation. An alternative would
-be to expose a flat list of behaviors, and allow the user to manipulate that list to change precedence. Ultimately, this was discarded as an overly-
-complex interface with diminishing benefits. However, feedback is welcome on a more elegant way to give users control of behavior ordering.
+Behaviors are ordered and precedence is used to determine how to route requests
+to origin(s). For example, origin #1 could have custom behaviors with path
+patterns of 'images/\*.jpg' and '\*.gif', and origin #2 could have a behavior on
+'images/\*'. Depending on the ordering, a request for 'images/foo.gif' may
+either be routed to origin #1 or #2. The approach taken ties behavior precedence
+to order of creation. An alternative would be to expose a flat list of
+behaviors, and allow the user to manipulate that list to change precedence.
+Ultimately, this was discarded as an overly- complex interface with diminishing
+benefits. However, feedback is welcome on a more elegant way to give users
+control of behavior ordering.
 
 # Adoption Strategy
 
-Once created, the new L2s can be used by existing CDK developers for new use cases, or by converting their existing CloudFrontWebDistribution usages
-to the new cloudfront.Distribution resource.
+Once created, the new L2s can be used by existing CDK developers for new use
+cases, or by converting their existing CloudFrontWebDistribution usages to the
+new cloudfront.Distribution resource.
 
 # Unresolved questions
 
-1. What level of breaking changes are acceptable for the existing `IDistribution` and `CloudFrontWebDistribution` resources? Notably, the
-`IDistribution` interface should extend `IResource`, and `CloudFrontWebDistribution` changed from extending `Construct` to `Resource`. Is this
-worth it, given the breaking changes to existing consumers? The alternative is to leave both `IDistribution` and `CloudFrontWebDistribution` as-is,
-and have `Distribution` directly extend `Resource`.
-2. Related to the above, should the current (CloudFrontWebDistribution) construct be marked as "stable" to indicate we won't be making future
-updates to it? Any other suggestions on how we message the "v2" on the README to highlight the new option to customers?
-3. Any better patterns for associating the Origin with the Distribution than something like the proposed `_attachDistribution`?
+1. What level of breaking changes are acceptable for the existing
+   `IDistribution` and `CloudFrontWebDistribution` resources? Notably, the
+   `IDistribution` interface should extend `IResource`, and
+   `CloudFrontWebDistribution` changed from extending `Construct` to `Resource`.
+   Is this worth it, given the breaking changes to existing consumers? The
+   alternative is to leave both `IDistribution` and `CloudFrontWebDistribution`
+   as-is, and have `Distribution` directly extend `Resource`.
+2. Related to the above, should the current (CloudFrontWebDistribution)
+   construct be marked as "stable" to indicate we won't be making future updates
+   to it? Any other suggestions on how we message the "v2" on the README to
+   highlight the new option to customers?
+3. Any better patterns for associating the Origin with the Distribution than
+   something like the proposed `_attachDistribution`?
 
 # Future Possibilities
 
-One extension point for this redesign is building all-in-one "L3s" on top of the new L2s. One extremely common use case for CloudFront is
-to be used as a globally-distributed front on top of a S3 bucket configured for website hosting. One potential L3 for CloudFront would wrap
-this entire set of constructs into one easy-to-use construct. For example:
+One extension point for this redesign is building all-in-one "L3s" on top of the
+new L2s. One extremely common use case for CloudFront is to be used as a
+globally-distributed front on top of a S3 bucket configured for website hosting.
+One potential L3 for CloudFront would wrap this entire set of constructs into
+one easy-to-use construct. For example:
 
 ```ts
 // Creates the hosted zone, S3 bucket, CloudFront distribution, ACM certificate, and wires everything together.
@@ -491,5 +608,6 @@ new StaticWebsiteDistribution(this, 'SiteDistribution', {
 });
 ```
 
-This would be relatively easy to piece together from the existing constructs, and would follow the patterns of the aws-s3-deployment module
-to deploy the assets.
+This would be relatively easy to piece together from the existing constructs,
+and would follow the patterns of the aws-s3-deployment module to deploy the
+assets.

--- a/text/0192-remove-constructs-compat.md
+++ b/text/0192-remove-constructs-compat.md
@@ -24,8 +24,9 @@ and new projects such as CDK for Kubernetes.
 
 This RFC describes the motivation, implications and plan for this project.
 
-[AWS CDK v2.0]: https://github.com/aws/aws-cdk-rfcs/issues/156
-[construct-compat.ts]: https://github.com/aws/aws-cdk/blob/fcca86e82235387b88371a0682cd0fc88bc1b67e/packages/%40aws-cdk/core/lib/construct-compat.ts
+[aws cdk v2.0]: https://github.com/aws/aws-cdk-rfcs/issues/156
+[construct-compat.ts]:
+  https://github.com/aws/aws-cdk/blob/fcca86e82235387b88371a0682cd0fc88bc1b67e/packages/%40aws-cdk/core/lib/construct-compat.ts
 
 ## Table of Contents
 
@@ -79,8 +80,8 @@ This RFC describes the motivation, implications and plan for this project.
 > This section "works backwards" from the v2.0 release notes in order to
 > describe the user impact of this change.
 
-**BREAKING CHANGE**: As part of CDK v2.0, all types related to the *constructs
-programming model* have been removed from the AWS CDK and should be used
+**BREAKING CHANGE**: As part of CDK v2.0, all types related to the _constructs
+programming model_ have been removed from the AWS CDK and should be used
 directly from the [constructs](https://github.com/aws/constructs) library.
 
 For most CDK libraries and apps, you will likely just need change this:
@@ -99,7 +100,7 @@ Additionally, The `node` property in `Construct` is now called `construct`. This
 means, for example, order to find the `path` of a construct `foo`, use:
 
 ```ts
-foo.construct.path // instead of `foo.node.path`
+foo.construct.path; // instead of `foo.node.path`
 ```
 
 ---
@@ -108,25 +109,25 @@ The following table summarizes the API changes between 1.x and 2.x. The
 following sections describe all the related breaking changes and details
 migration strategies for each change.
 
-1.x|2.x
-------|-----
-`@aws-cdk/*` | `aws-cdk-lib` and `constructs@^4`
-`import { Construct } from '@aws-cdk/core'` | `import { Construct } from 'constructs'`
-`@aws-cdk/core.Construct` | `constructs.Construct`
-`@aws-cdk/core.IConstruct` | `constructs.IConstruct`
-`@aws-cdk/core.ConstructOrder` | `constructs.ConstructOrder`
-`@aws-cdk/core.ConstructNode` | `constructs.Node`
-`myConstruct.node` | `myConstruct.construct`
-`myConstruct.node.applyAspect(aspect)` | `Aspects.of(myConstruct).add(aspect)`
-`@aws-cdk/core.IDependable` | `constructs.IDependable`
-`@aws-cdk/core.DependencyTrait` | `constructs.Dependable`
-`@aws-cdk.core.DependencyTrait.get(x)` | `constructs.Dependable.of(x)`
-`myConstruct.`node.dependencies`| Is now non-transitive
-`myConstruct.`addMetadata()`| Stack trace not attached by default
-`ConstructNode.prepareTree()`,`node.prepare()`,`onPrepare()`,`prepare()`| Not supported, use aspects instead
-`ConstructNode.synthesizeTree()`,`node.synthesize()`,`onSynthesize()`,`synthesize()`| Not supported
-`myConstruct.`onValidate()`,`myConstruct.`validate()`hooks | Implement`constructs.IValidation`and call`myConstruct.construct.addValidation()`instead
-`ConstructNode.validate(node)`|`myConstruct.construct.validate()`
+| 1.x                                                                                  | 2.x                                                                                     |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| `@aws-cdk/*`                                                                         | `aws-cdk-lib` and `constructs@^4`                                                       |
+| `import { Construct } from '@aws-cdk/core'`                                          | `import { Construct } from 'constructs'`                                                |
+| `@aws-cdk/core.Construct`                                                            | `constructs.Construct`                                                                  |
+| `@aws-cdk/core.IConstruct`                                                           | `constructs.IConstruct`                                                                 |
+| `@aws-cdk/core.ConstructOrder`                                                       | `constructs.ConstructOrder`                                                             |
+| `@aws-cdk/core.ConstructNode`                                                        | `constructs.Node`                                                                       |
+| `myConstruct.node`                                                                   | `myConstruct.construct`                                                                 |
+| `myConstruct.node.applyAspect(aspect)`                                               | `Aspects.of(myConstruct).add(aspect)`                                                   |
+| `@aws-cdk/core.IDependable`                                                          | `constructs.IDependable`                                                                |
+| `@aws-cdk/core.DependencyTrait`                                                      | `constructs.Dependable`                                                                 |
+| `@aws-cdk.core.DependencyTrait.get(x)`                                               | `constructs.Dependable.of(x)`                                                           |
+| `myConstruct.`node.dependencies`                                                     | Is now non-transitive                                                                   |
+| `myConstruct.`addMetadata()`                                                         | Stack trace not attached by default                                                     |
+| `ConstructNode.prepareTree()`,`node.prepare()`,`onPrepare()`,`prepare()`             | Not supported, use aspects instead                                                      |
+| `ConstructNode.synthesizeTree()`,`node.synthesize()`,`onSynthesize()`,`synthesize()` | Not supported                                                                           |
+| `myConstruct.`onValidate()`,`myConstruct.`validate()`hooks                           | Implement`constructs.IValidation`and call`myConstruct.construct.addValidation()`instead |
+| `ConstructNode.validate(node)`                                                       | `myConstruct.construct.validate()`                                                      |
 
 ### 00-DEPENDENCY: Declare a dependency on "constructs"
 
@@ -139,7 +140,7 @@ the AWS CDK. You will likely also want to declare those as `devDependencies` in
 order to be able to run tests in your build environment.
 
 To increase interoperability of your library, the recommendation is to use the
-lowest possible __caret__ version:
+lowest possible **caret** version:
 
 ```json
 {
@@ -173,12 +174,17 @@ never introduce breaking changes. Therefore, it's version will be `10.x`.
 
 The following `@aws-cdk/core` types have stand-in replacements in `constructs`:
 
-- The `@aws-cdk/core.Construct` class has been replaced with `constructs.Construct`
-- The `@aws-cdk/core.IConstruct` type has been replaced with `constructs.IConstruct`
-- The `@aws-cdk/core.ConstructOrder` class has been replaced with `constructs.ConstructOrder`
-- The `@aws-cdk/core.ConstructNode` class has been replaced with `constructs.Node`
+- The `@aws-cdk/core.Construct` class has been replaced with
+  `constructs.Construct`
+- The `@aws-cdk/core.IConstruct` type has been replaced with
+  `constructs.IConstruct`
+- The `@aws-cdk/core.ConstructOrder` class has been replaced with
+  `constructs.ConstructOrder`
+- The `@aws-cdk/core.ConstructNode` class has been replaced with
+  `constructs.Node`
 
-See [examples](https://github.com/aws/aws-cdk/pull/9056/commits/e4dff913d486592b1899182e9a928765553654fa).
+See
+[examples](https://github.com/aws/aws-cdk/pull/9056/commits/e4dff913d486592b1899182e9a928765553654fa).
 
 ### 10-CONSTRUCT-NODE: `myConstruct.node` is now `myConstrct.construct`
 
@@ -213,7 +219,8 @@ scope, use:
 Tags.of(scope).add(name, value);
 ```
 
-See [examples](https://github.com/aws/aws-cdk/pull/9056/commits/e4dff913d486592b1899182e9a928765553654fa).
+See
+[examples](https://github.com/aws/aws-cdk/pull/9056/commits/e4dff913d486592b1899182e9a928765553654fa).
 
 ### 03-DEPENDABLE: Changes to IDependable implementation
 
@@ -227,13 +234,14 @@ If you need to implement `IDependable`:
 - `c.construct.dependencies` is now **non-transitive** and returns only the
   dependencies added to the current node.
 
-The method `c.construct.addDependency(otherConstruct)` __did not change__ and
+The method `c.construct.addDependency(otherConstruct)` **did not change** and
 can be used as before.
 
-> You can use the new `c.construct.dependencyGraph`  to access a rich object
+> You can use the new `c.construct.dependencyGraph` to access a rich object
 > model for reflecting on the node's dependency graph.
 
-See [examples](https://github.com/aws/aws-cdk/pull/9056/commits/e4dff913d486592b1899182e9a928765553654fa).
+See
+[examples](https://github.com/aws/aws-cdk/pull/9056/commits/e4dff913d486592b1899182e9a928765553654fa).
 
 ### 04-STACK-ROOT: Stacks as root constructs
 
@@ -254,22 +262,23 @@ Please note that this also means that the value of `construct.path` for all
 constructs in the tree would now have a `Default/` prefix (if it was `Foo/Bar`
 it will now be `Default/Foo/Bar`).
 
-> In contrast, the value of `construct.uniqueId` will _not_ change because `Default`
-> is a special ID that is ignored when calculating unique IDs (this feature
-> already exists in 1.x).
+> In contrast, the value of `construct.uniqueId` will _not_ change because
+> `Default` is a special ID that is ignored when calculating unique IDs (this
+> feature already exists in 1.x).
 
 ### 05-METADATA-TRACES: Stack traces no longer attached to metadata by default
 
-For performance reasons, the `c.construct.addMetadata()` method will *not*
+For performance reasons, the `c.construct.addMetadata()` method will _not_
 attach stack traces to metadata entries. Stack traces will still be associated
 with all `CfnResource` constructs and can also be added to custom metadata using
 the `stackTrace` option:
 
 ```ts
-c.construct.addMetadata(key, value, { stackTrace: true })
+c.construct.addMetadata(key, value, { stackTrace: true });
 ```
 
-See [examples](https://github.com/aws/aws-cdk/pull/9056/commits/e4dff913d486592b1899182e9a928765553654fa).
+See
+[examples](https://github.com/aws/aws-cdk/pull/9056/commits/e4dff913d486592b1899182e9a928765553654fa).
 
 ### 06-NO-PREPARE: The `prepare` hook is no longer supported
 
@@ -280,7 +289,8 @@ when the tree is mutated during this stage.
 Consider a design where you mutate the tree in-band, or use `Lazy` values or
 Aspects if appropriate.
 
-See [examples](https://github.com/aws/aws-cdk/pull/9056/commits/3d4fcb5ab72ca0777f3abfa2c4aa10e0d7deba6b).
+See
+[examples](https://github.com/aws/aws-cdk/pull/9056/commits/3d4fcb5ab72ca0777f3abfa2c4aa10e0d7deba6b).
 
 Although we recommend that you rethink the use of "prepare", you can use this
 idiom to implement "prepare" using aspects:
@@ -301,26 +311,28 @@ If your use case for overriding `synthesize()` was to emit files into the cloud
 assembly directory, you can now find the current cloud assembly output directory
 during initialization using `Stage.of(this).outdir`.
 
-See [examples](https://github.com/aws/aws-cdk/pull/9056/commits/02b45b50c27fffae1bfbc4f61f6adc1f8fd92672).
+See
+[examples](https://github.com/aws/aws-cdk/pull/9056/commits/02b45b50c27fffae1bfbc4f61f6adc1f8fd92672).
 
 The `ConstructNode.synthesize(node)` method no longer exists. However, since now
-`Stage.of(scope)` is always defined and returns the enclosing stage/app, you
-can can synthesize a construct node through `Stage.of(scope).synth()`.
+`Stage.of(scope)` is always defined and returns the enclosing stage/app, you can
+can synthesize a construct node through `Stage.of(scope).synth()`.
 
 For additional questions/guidance on how to implement your use case without this
-hook, please post a comment on [this GitHub issue](https://github.com/aws/aws-cdk/issues/8909).
+hook, please post a comment on
+[this GitHub issue](https://github.com/aws/aws-cdk/issues/8909).
 
 ### 08-VALIDATION: The `validate()` hook is now `node.addValidation()`
 
-To add validation logic to a construct, use `c.construct.addValidation()`
-method instead of overriding a protected `validate()` method:
+To add validation logic to a construct, use `c.construct.addValidation()` method
+instead of overriding a protected `validate()` method:
 
 Before:
 
 ```ts
 class MyConstruct extends Construct {
   protected validate(): string[] {
-    return [ 'validation-error' ];
+    return ['validation-error'];
   }
 }
 ```
@@ -332,7 +344,7 @@ class MyConstruct extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    this.construct.addValidation({ validate: () => [ 'validation-error' ] });
+    this.construct.addValidation({ validate: () => ['validation-error'] });
   }
 }
 ```
@@ -362,7 +374,8 @@ import { Annotations } from '@aws-cdk/core';
 Annotations.of(construct).addWarning('my warning');
 ```
 
-See [examples](https://github.com/aws/aws-cdk/pull/9056/commits/e4dff913d486592b1899182e9a928765553654fa).
+See
+[examples](https://github.com/aws/aws-cdk/pull/9056/commits/e4dff913d486592b1899182e9a928765553654fa).
 
 ## Motivation
 
@@ -397,9 +410,9 @@ constructs with constructs from other domains.
 It is currently impossible to define AWS CDK constructs within a non-AWS-CDK
 construct scope.
 
-For example, consider the [CDK for
-Terraform](https://github.com/hashicorp/terraform-cdk) or a similar project,
-which uses constructs to define stacks through Terraform.
+For example, consider the
+[CDK for Terraform](https://github.com/hashicorp/terraform-cdk) or a similar
+project, which uses constructs to define stacks through Terraform.
 
 We are currently working with HashiCorp to enable the following use case in the
 Terraform CDK:
@@ -446,7 +459,8 @@ on the `constructs` library.
 
 See the RFC for [monolithic packaging] for more details.
 
-[monolithic packaging]: https://github.com/aws/aws-cdk-rfcs/blob/master/text/0006-monolothic-packaging.md
+[monolithic packaging]:
+  https://github.com/aws/aws-cdk-rfcs/blob/master/text/0006-monolothic-packaging.md
 
 ## Design
 
@@ -457,14 +471,15 @@ For each change, we added a **What can we do on 1.x?** section which discusses
 our strategy for front-loading the change into the 1.x branch to reduce forking
 costs and/or alert users of the upcoming deprecation.
 
-This design is based on this [proof of concept](https://github.com/aws/aws-cdk/pull/9056).
+This design is based on this
+[proof of concept](https://github.com/aws/aws-cdk/pull/9056).
 
 ### 00-DEPENDENCY
 
 In order to enable composability with other CDK domains (Terraform, Kubernetes),
 all constructs must use the same version of the `Construct` base class.
 
-As long as all libraries in a closure take a __peer dependency__ on a compatible
+As long as all libraries in a closure take a **peer dependency** on a compatible
 version of `constructs`, the npm package manger will include a single copy of
 the library, and therefore all constructs will derive from the same `Construct`
 (and more importantly, accept the same `Construct` for `scope`).
@@ -474,8 +489,8 @@ Practically this means that we can never introduce a major version of
 CDKs, and that is impossible to require or coordinate given the decentralized
 nature of the ecosystem.
 
-We propose to take a commitment to __never introduce breaking changes in
-"constructs"__. This implies that we will never introduce another major version.
+We propose to take a commitment to **never introduce breaking changes in
+"constructs"**. This implies that we will never introduce another major version.
 To symbolize that to users, we will use the major version `10.x`.
 
 ### 01-BASE-TYPES
@@ -493,7 +508,7 @@ The main concern for the CDK codebase is maintaining this change alongside a 1.x
 branch until we switch over to 2.x. Since this change includes modifications to
 all `import` sections in almost all of our files, merge conflicts are imminent.
 
-To reduce these costs, we propose to modify the `scope` argument on all  1.x to
+To reduce these costs, we propose to modify the `scope` argument on all 1.x to
 accept `constructs.Construct` instead of `core.Construct`.
 
 This will provide the following benefits (enforced by an `awslint` rule):
@@ -503,9 +518,9 @@ This will provide the following benefits (enforced by an `awslint` rule):
 2. It will unlock composition of framework constructs into other domains (e.g.
    it will be possible to pass an AWS CDK L2 to a terraform stack).
 
-Note that we will *not* change the base classes to `constructs.Construct`
-because it is technically (and practically) a breaking API change (we must maintain
-the invariant that "`s3.Bucket` is a `core.Construct`".
+Note that we will _not_ change the base classes to `constructs.Construct`
+because it is technically (and practically) a breaking API change (we must
+maintain the invariant that "`s3.Bucket` is a `core.Construct`".
 
 The remaining change in 2.x will be to update any base classes to use
 `constructs.Construct` but this is actually not very prevalent in the framework
@@ -513,42 +528,44 @@ code because the majority of constructs actually extend `core.Resource`.
 
 Alternatives considered:
 
-- **Do nothing in 1.x**: will incur an ongoing maintenance cost of the 1.x -> 2.x
-  merge conflicts.
+- **Do nothing in 1.x**: will incur an ongoing maintenance cost of the 1.x ->
+  2.x merge conflicts.
 - **Automatic merge resolution and import organization**: requires research and
   development, not necessarily worth it.
 
 ### 10-CONSTRUCT-NODE
 
-Since we won't be able to release additional major versions of the
-"constructs" library (in order to ensure interoperability between domains is always
+Since we won't be able to release additional major versions of the "constructs"
+library (in order to ensure interoperability between domains is always
 possible), we need to closely examine the API of this library.
 
 In particular, the API of the `Construct` class, which is the base of all
 constructs in all CDKs, should be as small as possible in order not to "pollute"
 domain-specific APIs introduced in various domains.
 
-In many cases (cdk8s, cdktf), constructs are *generated* on-demand from
+In many cases (cdk8s, cdktf), constructs are _generated_ on-demand from
 domain-specific API specifications. In such cases, we need to ensure that the
 API in `Construct` does not conflict with generated property names or methods.
 
-The current API of `Construct` in the base class (2.x, 3.x) only includes a
-few protected `onXxx` methods (`onPrepare`, `onValidate` and
-`onSynthesize`). Those methods will be removed in 10.x
-([prepare](#06-no-prepare) and [synthesize](#07-no-synthesize) are no longer
-supported and [validate](#08-validation) will be supported through
-`addValidation()`).
+The current API of `Construct` in the base class (2.x, 3.x) only includes a few
+protected `onXxx` methods (`onPrepare`, `onValidate` and `onSynthesize`). Those
+methods will be removed in 10.x ([prepare](#06-no-prepare) and
+[synthesize](#07-no-synthesize) are no longer supported and
+[validate](#08-validation) will be supported through `addValidation()`).
 
-In AWS CDK 1.x the construct API is available under `myConstruct.node`. This
-API has been intentionally removed when we extracted "constructs" from the AWS CDK
-in order to allow the compatibility layer in AWS CDK 1.x to use the same property name
-and expose the shim type (jsii does not allow changing the type of a property in a subclass).
+In AWS CDK 1.x the construct API is available under `myConstruct.node`. This API
+has been intentionally removed when we extracted "constructs" from the AWS CDK
+in order to allow the compatibility layer in AWS CDK 1.x to use the same
+property name and expose the shim type (jsii does not allow changing the type of
+a property in a subclass).
 
-The base library currently offers `Node.of(scope)` as an alternative - but this API is cumbersome
-to use and not discoverable. In evidence, in CDK for Terraform, they chose to offer [`constructNode`]
-in `TerraformElement` as a sugar for `Node.of()`.
+The base library currently offers `Node.of(scope)` as an alternative - but this
+API is cumbersome to use and not discoverable. In evidence, in CDK for
+Terraform, they chose to offer [`constructNode`] in `TerraformElement` as a
+sugar for `Node.of()`.
 
-[`constructNode`]: https://github.com/hashicorp/terraform-cdk/blob/5becfbc699180adfe920dec794200bbf56dda0a7/packages/cdktf/lib/terraform-element.ts#L21
+[`constructnode`]:
+  https://github.com/hashicorp/terraform-cdk/blob/5becfbc699180adfe920dec794200bbf56dda0a7/packages/cdktf/lib/terraform-element.ts#L21
 
 Another downside of `Node.of()` is that it means that the `IConstruct` interface
 is now an empty interface, which is a very weak type in TypeScript due to
@@ -558,20 +575,21 @@ As we evaluate this use case for constructs 10.x, we would like to restore the
 ability to access the construct API from a property of `Construct`, and use that
 property as the single marker that represents a construct type (`IConstruct`).
 
-To reduce the risk of naming conflicts (e.g. see [Terraform CDK
-issue](https://github.com/hashicorp/terraform-cdk/pull/230)) between `node` and
-domain-specific APIs, we propose to introduce this API under the name
-`construct` (of type `Node`).
+To reduce the risk of naming conflicts (e.g. see
+[Terraform CDK issue](https://github.com/hashicorp/terraform-cdk/pull/230))
+between `node` and domain-specific APIs, we propose to introduce this API under
+the name `construct` (of type `Node`).
 
 This has a few benefits:
 
 1. It's semantically signals that "this is the construct API".
-2. The chance for conflicts with domain-specific names is low ("construct" is not prevalent).
+2. The chance for conflicts with domain-specific names is low ("construct" is
+   not prevalent).
 3. We can introduce this API while deprecating `node` in AWS CDK 1.x.
 
 The main downside is that it is **a breaking change** in AWS CDK 2.x. There is
-likely quite a lot of code out there (a [few
-hundred](https://github.com/search?q=cdk+node.addDependency++extension%3Ats&type=Code&ref=advsearch&l=&l=)
+likely quite a lot of code out there (a
+[few hundred](https://github.com/search?q=cdk+node.addDependency++extension%3Ats&type=Code&ref=advsearch&l=&l=)
 results for an approximated GitHub code search).
 
 > We also considered the name `constructNode` as an alternative but there is no
@@ -590,7 +608,8 @@ through a runtime warning message (as well as the @deprecated API annotation).
 
 #### Alternative Considered
 
-See [discussion](https://github.com/aws/aws-cdk-rfcs/pull/195/files#r460718960) over the RFC PR.
+See [discussion](https://github.com/aws/aws-cdk-rfcs/pull/195/files#r460718960)
+over the RFC PR.
 
 ### 02-ASPECTS
 
@@ -599,8 +618,8 @@ their execution order becomes critical and extremely hard to get right. To that
 end, we decided to remove them from the `constructs` library as they pose a risk
 to the programming model.
 
-However, we are aware that aspects are used by AWS CDK apps and even 3rd
-party libraries such as [cdk-watchful](https://github.com/eladb/cdk-watchful).
+However, we are aware that aspects are used by AWS CDK apps and even 3rd party
+libraries such as [cdk-watchful](https://github.com/eladb/cdk-watchful).
 
 Therefore, we propose to continue to support aspects in 2.x, with the goal of
 rethinking this programming model for a future major version. One future
@@ -620,8 +639,8 @@ The major downside of this change is discoverability, but
 `construct.node.applyAspect` is not necessarily more discoverable. We will make
 sure documentation is clear.
 
-We will use this opportunity to normalize the tags API and change it to use the same
-pattern: `Tags.of(x).add(name, value)`.
+We will use this opportunity to normalize the tags API and change it to use the
+same pattern: `Tags.of(x).add(name, value)`.
 
 #### What can we do on 1.x for 02-ASPECTS
 
@@ -691,15 +710,15 @@ example:
 
 ```ts
 const stack = new Stack();
-const c1 = new MyConstruct(stack, 'c1', { foos: [ 'bar' ] });
+const c1 = new MyConstruct(stack, 'c1', { foos: ['bar'] });
 expect(stack).toHaveResource('AWS::Resource', {
-  Foos: [ 'bar' ]
+  Foos: ['bar'],
 });
 
 // now add a "foo" and verify that the synthesized template contains two items
 c1.addFoo('baz');
 expect(stack).toHaveResource('AWS::Resource', {
-  Foos: [ 'bar', 'baz' ]
+  Foos: ['bar', 'baz'],
 });
 ```
 
@@ -719,9 +738,10 @@ Since `uniqueId` is used in several places throughout the AWS Construct Library
 to allocate names for resources, and we have multiple unit tests that expect
 these values, we will use the ID `Default` for the root stack.
 
-The `uniqueId` algorithm in the constructs library (see [reference](https://github.com/aws/constructs/blob/d5c3ee0a89e09318838f78bfb89832c0548d846d/src/private/uniqueid.ts#L33))
-ignores any node with the ID `Default` for the purpose of calculating the unique ID,
-which allows us to perform this change without breaking unique IDs.
+The `uniqueId` algorithm in the constructs library (see
+[reference](https://github.com/aws/constructs/blob/d5c3ee0a89e09318838f78bfb89832c0548d846d/src/private/uniqueid.ts#L33))
+ignores any node with the ID `Default` for the purpose of calculating the unique
+ID, which allows us to perform this change without breaking unique IDs.
 
 We will accept the fact that `node.path` is going to change for this specific
 use case (only relevant in tests).
@@ -787,7 +807,8 @@ The prepare hook was used in the CDK in a few cases:
    Deployment, Lambda Version).
 
 The first two use cases have already been addressed by centralizing the
-"prepare" logic at the stage level (into [prepare-app.ts](https://github.com/aws/aws-cdk/blob/master/packages/%40aws-cdk/core/lib/private/prepare-app.ts)).
+"prepare" logic at the stage level (into
+[prepare-app.ts](https://github.com/aws/aws-cdk/blob/master/packages/%40aws-cdk/core/lib/private/prepare-app.ts)).
 
 #### What can we do on 1.x for 06-NO-PREPARE
 
@@ -804,15 +825,15 @@ Version 4.x of the `constructs` library does not contain a lifecycle hook for
 synthesis as described [above](#the-synthesize-hook-is-no-longer-supported).
 
 The reason this is not available at the base class is because the abstraction
-did not "hold water" as the AWS CDK evolved and new CDKs emerged.  In the AWS
+did not "hold water" as the AWS CDK evolved and new CDKs emerged. In the AWS
 CDK, we eventually ended up with a centralized synthesis logic at the
 `Stage`-level
 ([synthesis.ts](https://github.com/aws/aws-cdk/blob/master/packages/%40aws-cdk/core/lib/private/synthesis.ts)).
 The main reason was that we needed to "break" the recursion in various
 domain-specific points (e.g. stages, nested stacks) which meant that the generic
 logic of "traverse the entire tree and call `synthesize`" did not hold. In
-`cdk8s`, the support for [chart
-dependencies](https://github.com/awslabs/cdk8s/blob/ef95b9ffce8a39200e028c2fe8acc55a9915161c/packages/cdk8s/src/app.ts#L39)
+`cdk8s`, the support for
+[chart dependencies](https://github.com/awslabs/cdk8s/blob/ef95b9ffce8a39200e028c2fe8acc55a9915161c/packages/cdk8s/src/app.ts#L39)
 required that the name of the output manifest will be determined based on the
 topologic order at the app level. Here again, the generic approach failed.
 
@@ -827,9 +848,11 @@ provided at the base `Construct` class.
 
 In the AWS CDK itself, `synthesize()` was used in three locations:
 
-1. `Stack` - creates a CFN template and adds itself to the cloud assembly manifest.
+1. `Stack` - creates a CFN template and adds itself to the cloud assembly
+   manifest.
 2. `AssetStaging` - stages an asset into the cloud assembly.
-3. `TreeMetadata` - creates `tree.json` with information about the construct tree.
+3. `TreeMetadata` - creates `tree.json` with information about the construct
+   tree.
 
 For `Stack` and `TreeMetadata`, we will convert the generic `synthesize()`
 method to `_synthesizeTemplate()` and `_synthesizeTree()` and will call them
@@ -862,7 +885,8 @@ initialization, it is possible to find out the output directory through
 
 #### What can we do on 1.x for 07-NO-SYNTHESIZE
 
-1. The framework changes should be done on the 1.x branch as they are non-breaking.
+1. The framework changes should be done on the 1.x branch as they are
+   non-breaking.
 2. We will also add a deprecation notice that identifies the existence of a
    `synthesize()` method on a construct (during synthesis) and warns users that
    this hook will no longer be available in 2.x, offering a GitHub issue for
@@ -890,7 +914,8 @@ We decided that logging is not generic enough to include in `constructs`. It
 emits construct metadata that is very CLI specific (e.g. `aws:cdk:warning`) and
 currently there is no strong abstraction.
 
-To continue to enable logging, we will utilize the `Annotations.of(x).addWarning()` pattern.
+To continue to enable logging, we will utilize the
+`Annotations.of(x).addWarning()` pattern.
 
 #### What can we do on 1.x for 09-LOGGING
 
@@ -937,11 +962,11 @@ they evolve over time (for example, a CDK engineer may be tempted to add an
 AWS-specific feature in this layer, making it harder to clean up later).
 
 If we consider the various [reasons](#drawbacks) not to take this change, the
-main reason would be to simplify the [migration for users from 1.x to
-2.x](#user-migration-effort). The major version 2.x is already required to
-introduce monolithic packaging, and this change, for most users, is likely to be
-trivial (see [above](#breaking-changes)). Therefore, we believe this is probably
-not the correct motivation to reject this proposal.
+main reason would be to simplify the
+[migration for users from 1.x to 2.x](#user-migration-effort). The major version
+2.x is already required to introduce monolithic packaging, and this change, for
+most users, is likely to be trivial (see [above](#breaking-changes)). Therefore,
+we believe this is probably not the correct motivation to reject this proposal.
 
 The [repository migration](#repository-migration-efforts) efforts and
 [co-existence of 2.x/1.x](#co-existence-of-2x1x) are both one-off costs this
@@ -967,7 +992,8 @@ Another alternative is to rename `cdk.Construct` to something like
 `AwsConstruct`. This, would take up most of the cost of this change (which is
 the CDK codebase change and merge risks against the fork).
 
-Postponing to v3.x will leave us with the set exact set of problems, only with a more mature ecosystem which is harder to migrate off of.
+Postponing to v3.x will leave us with the set exact set of problems, only with a
+more mature ecosystem which is harder to migrate off of.
 
 The [Design](#design) section describes alternatives for various aspects of this
 project.
@@ -991,9 +1017,10 @@ See [Release Notes](#release-notes).
 ## Future Possibilities
 
 > Think about what the natural extension and evolution of your proposal would be
-> and how it would affect CDK as whole. Try to use this section as a tool to more
-> fully consider all possible interactions with the project and ecosystem in your
-> proposal. Also consider how this fits into the roadmap for the project.
+> and how it would affect CDK as whole. Try to use this section as a tool to
+> more fully consider all possible interactions with the project and ecosystem
+> in your proposal. Also consider how this fits into the roadmap for the
+> project.
 >
 > This is a good place to "dump ideas", if they are out of scope for the RFC you
 > are writing but are otherwise related.
@@ -1008,16 +1035,16 @@ See [Release Notes](#release-notes).
 We will try to front load as much of this change to 1.x in order to reduce the
 merge conflict potential.
 
-To that end, we will continuously merge from "master" into [the POC
-branch](https://github.com/aws/aws-cdk/pull/9056) and slowly back port changes
-from it into `master` as much as possible. The goal is the minimize the changes
-between master and the POC branch which will be merged into the 2.x branch once
-created.
+To that end, we will continuously merge from "master" into
+[the POC branch](https://github.com/aws/aws-cdk/pull/9056) and slowly back port
+changes from it into `master` as much as possible. The goal is the minimize the
+changes between master and the POC branch which will be merged into the 2.x
+branch once created.
 
 - [01-BASE-TYPES](#01-base-types)
   - [ ] Normalize reference to base types (`cdk.Construct` => `Construct`).
   - [ ] Use an `awslint` rule to modify the `scope` argument on all 1.x to
-    accept `constructs.Construct` instead of `core.Construct`
+        accept `constructs.Construct` instead of `core.Construct`
 - [10-CONSTRUCT-NODE](#10-construct-node)
   - [ ] Introduce `c.construct` as an alias to `c.node`
   - [ ] Deprecate `c.node` (with a warning message)
@@ -1027,28 +1054,28 @@ created.
   - [ ] Introduce `Tags.of()` and deprecate `Tag.add()`
 - [03-DEPENDABLE](#03-dependable)
   - [ ] Introduce `Dependable` as an alias to `DependencyTrait`, introduce
-    `DependencyGroup`
+        `DependencyGroup`
 - [04-STACK-ROOT](#04-stack-root)
   - [ ] Introduce `node.relocate()` in constructs 3.x
   - [ ] Implement implicit `App` for root `Stack`s, relocated to "".
 - [05-METADATA-TRACES](#05-metadata-traces)
   - N/A
 - [06-NO-PREPARE](#06-no-prepare)
-  - [ ] Back port [this
-    commit](https://github.com/aws/aws-cdk/pull/9056/commits/3d4fcb5ab72ca0777f3abfa2c4aa10e0d7deba6b)
-    to master
+  - [ ] Back port
+        [this commit](https://github.com/aws/aws-cdk/pull/9056/commits/3d4fcb5ab72ca0777f3abfa2c4aa10e0d7deba6b)
+        to master
   - [ ] Add a deprecation warning if `onPrepare()` or `prepare()` is identified
-    on a construct during synthesis
+        on a construct during synthesis
 - [07-NO-SYNTHESIZE](#07-no-synthesize)
-  - [ ] Back port the changes related to synthesis from [this
-    commit](https://github.com/aws/aws-cdk/pull/9056/commits/02b45b50c27fffae1bfbc4f61f6adc1f8fd92672)
+  - [ ] Back port the changes related to synthesis from
+        [this commit](https://github.com/aws/aws-cdk/pull/9056/commits/02b45b50c27fffae1bfbc4f61f6adc1f8fd92672)
   - [ ] Add a deprecation warning if `onSynthezize()` or `synthesize()` is
-    declared on a construct
+        declared on a construct
 - [08-VALIDATION](#08-validation)
   - [ ] Introduce `node.addValidation()` and deprecate `validate()` and
-    `onValidate()` by back porting [this
-    commit](https://github.com/aws/aws-cdk/pull/9056/commits/42bd929aa36dc97ae39b15b77cf1f69d754c4a92)
-    to master
+        `onValidate()` by back porting
+        [this commit](https://github.com/aws/aws-cdk/pull/9056/commits/42bd929aa36dc97ae39b15b77cf1f69d754c4a92)
+        to master
 - [09-LOGGING](#09-logging)
   - [ ] Introduce `Annotations.of()` deprecate `node.addWarning/error/info`.
 
@@ -1067,13 +1094,15 @@ for constructs 10.x.
   - [x] Remove aspects (`IAspect` and `node.applyAspect`).
 - [03-DEPENDABLE](#03-dependable)
   - [x] Reintroduce dependencies (`IDependable`, `Dependable`,
-    `DependencyGroup`)
+        `DependencyGroup`)
   - [x] Change `node.dependencies` to return the list of node dependency (non
-    recursive) and add `node.depgraph` which returns a `Graph` object from
-    cdk8s.
+        recursive) and add `node.depgraph` which returns a `Graph` object from
+        cdk8s.
   - [x] Change `addDependency` to accept `IDependable` instead of `IConstruct`.
   - [x] Return only local dependencies in `node.dependencies`
-  - [ ] Migrate [DependencyGraph](https://github.com/awslabs/cdk8s/blob/master/packages/cdk8s/src/dependency.ts) from cdk8s into `constructs`.
+  - [ ] Migrate
+        [DependencyGraph](https://github.com/awslabs/cdk8s/blob/master/packages/cdk8s/src/dependency.ts)
+        from cdk8s into `constructs`.
 - [04-STACK-ROOT](#04-stack-root)
   - N/A
 - [05-METADATA-TRACES](#05-metadata-traces)
@@ -1091,8 +1120,8 @@ for constructs 10.x.
 ### 2.x Work
 
 - [ ] Once the 2.x branch will be created, we will merge the remaining changes
-  from the POC branch into it.
+      from the POC branch into it.
 - [ ] Write a migration guide with guidance on `synthesize` and `prepare` in
-  <https://github.com/aws/aws-cdk/issues/8909>
+      <https://github.com/aws/aws-cdk/issues/8909>
 - [ ] Updates to Developer Guide (add 2.x section)
 - [ ] Updates to READMEs across the library (add 2.x section)

--- a/tools/linters/markdownlint.json
+++ b/tools/linters/markdownlint.json
@@ -4,7 +4,7 @@
   "fenced-code-language": false,
   "first-line-h1": false,
   "line_length": {
-    "line_length": 150
+    "line_length": 80
   },
   "no-duplicate-heading": {
     "siblings_only": true


### PR DESCRIPTION
Modified linter rules and prettier config to standardize on 80 character lines. Diff viewing is somewhat difficult with the maximum set at 150, and sometimes edits are submitted by an author who has their setting at a different place like 100 or 120, which makes it hard to tell what actually changed. Since RFCs are mostly text, 80 characters seems reasonable.