### PR TITLE
chore: fix the 'render-table' GitHub workflow

### DIFF
--- a/.github/workflows/render-table.yml
+++ b/.github/workflows/render-table.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update RFC table in README


### PR DESCRIPTION
The workflow currently fails with:

```
/usr/bin/git config --local --unset http.https://github.com/.extraheader ^AUTHORIZATION:
/opt/hostedtoolcache/Python/3.9.1/x64/bin/python /home/runner/work/_actions/peter-evans/create-pull-request/v2/dist/cpr/create_pull_request.py
Error: Unable to process command '::set-env name=PULL_REQUEST_NUMBER::288' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

Update to version `v3` of the `peter-evans/create-pull-request` Action,
as it does not have this problem according to https://github.com/peter-evans/create-pull-request/issues/632.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_
