### PR TITLE
monocdk: add golang names

### DIFF
--- a/text/0006-monolothic-packaging.md
+++ b/text/0006-monolothic-packaging.md
@@ -290,7 +290,7 @@ import (
 
 app := awscdk.NewApp()
 stack := awscdk.NewStack(app, "MyStack");
-bucket := awscdk.aws_s3.NewBucket(stack, "MyBucket")
+bucket := awscdk.awss3.NewBucket(stack, "MyBucket")
 
 app.Synth();
 ```

--- a/text/0006-monolothic-packaging.md
+++ b/text/0006-monolothic-packaging.md
@@ -297,16 +297,17 @@ app.Synth();
 
 Migration path:
 
-Go users who will migrate from 1.x to 2.0 will only need to change their import (and `go.mod` "require" clause) 
+Go users who will migrate from 1.x to 2.0 will only need to change their import (and `go.mod` "require" clause)
 from `github.com/aws/aws-cdk-go/awscdk` to `github.com/aws/aws-cdk-go/awscdk/v2`.
 
 This will be achieved in the following way:
+
 - 1.x releases will publish `monocdk` under the module name `awscdk`
 - 2.x releases will publish `aws-cdk-lib` under the module name `awscdk`.
 
 Open issues:
-- The current go code generator does not support specifying a module name, only the repository name (tracked https://github.com/aws/jsii/issues/2632).
-
+- The current go code generator does not support specifying a module name, only the repository name 
+  (tracked via [aws/jsii#2632](https://github.com/aws/jsii/issues/2632)).
 
 ## Issues with Specific Modules
 

--- a/text/0006-monolothic-packaging.md
+++ b/text/0006-monolothic-packaging.md
@@ -286,11 +286,12 @@ Usage:
 ```go
 import (
     "github.com/aws/aws-cdk-go/awscdk"
+    s3 "github.com/aws/aws-cdk-go/awscdk/awss3"
 )
 
 app := awscdk.NewApp()
 stack := awscdk.NewStack(app, "MyStack");
-bucket := awscdk.awss3.NewBucket(stack, "MyBucket")
+bucket := s3.NewBucket(stack, "MyBucket")
 
 app.Synth();
 ```

--- a/text/0006-monolothic-packaging.md
+++ b/text/0006-monolothic-packaging.md
@@ -279,6 +279,35 @@ Open issues:
 - Should we use `aws_cdk` as the module name to preserve compatibility or rename
   to `aws_cdk_lib`?
 
+### Go
+
+Usage:
+
+```go
+import (
+    "github.com/aws/aws-cdk-go/awscdk"
+)
+
+app := awscdk.NewApp()
+stack := awscdk.NewStack(app, "MyStack");
+bucket := awscdk.aws_s3.NewBucket(stack, "MyBucket")
+
+app.Synth();
+```
+
+Migration path:
+
+Go users who will migrate from 1.x to 2.0 will only need to change their import (and `go.mod` "require" clause) 
+from `github.com/aws/aws-cdk-go/awscdk` to `github.com/aws/aws-cdk-go/awscdk/v2`.
+
+This will be achieved in the following way:
+- 1.x releases will publish `monocdk` under the module name `awscdk`
+- 2.x releases will publish `aws-cdk-lib` under the module name `awscdk`.
+
+Open issues:
+- The current go code generator does not support specifying a module name, only the repository name (tracked https://github.com/aws/jsii/issues/2632).
+
+
 ## Issues with Specific Modules
 
 ### cx-api, cloud-assembly-schema and asset-schema

--- a/text/0006-monolothic-packaging.md
+++ b/text/0006-monolothic-packaging.md
@@ -306,7 +306,8 @@ This will be achieved in the following way:
 - 2.x releases will publish `aws-cdk-lib` under the module name `awscdk`.
 
 Open issues:
-- The current go code generator does not support specifying a module name, only the repository name 
+
+- The current go code generator does not support specifying a module name, only the repository name
   (tracked via [aws/jsii#2632](https://github.com/aws/jsii/issues/2632)).
 
 ## Issues with Specific Modules

--- a/text/0079-cdk-2.0.md
+++ b/text/0079-cdk-2.0.md
@@ -273,12 +273,12 @@ sequentially increasing pre-release identifier. The following table describes
 the versioning scheme in the different package managers across the different
 phases.
 
-|                | Github & NPM                          | Maven Central                         | PyPI                          | NuGet                                 |
-| -------------- | ------------------------------------- | ------------------------------------- | ----------------------------- | ------------------------------------- |
-| **Spec**       | [semantic versioning]                 | [pom version order]                   | [python packaging]            | [nuget versioning]                    |
-| **Alpha**      | `2.0.0-alpha.1` <br/> `2.0.0-alpha.2` | `2.0.0-alpha.1` <br/> `2.0.0-alpha.2` | `2.0.0.a1` <br/> `2.0.0.a2`   | `2.0.0-alpha.1` <br/> `2.0.0-alpha.2` |
-| **DevPreview** | `2.0.0-rc.1` <br/> `2.0.0-rc.2`       | `2.0.0-rc.1` <br/> `2.0.0-rc.2`       | `2.0.0.rc1` <br/> `2.0.0.rc2` | `2.0.0-rc.1` <br/> `2.0.0-rc.2`       |
-| **GA**         | `2.0.0` <br/> `2.1.0`                 | `2.0.0` <br/> `2.1.0`                 | `2.0.0` <br/> `2.1.0`         | `2.0.0` <br/> `2.1.0`                 |
+|                | Github & NPM                          | Maven Central                         | PyPI                          | NuGet                                 | Go                                    |
+| -------------- | ------------------------------------- | ------------------------------------- | ----------------------------- | ------------------------------------- | ------------------------------------- |
+| **Spec**       | [semantic versioning]                 | [pom version order]                   | [python packaging]            | [nuget versioning]                    | [go versioning]                       |
+| **Alpha**      | `2.0.0-alpha.1` <br/> `2.0.0-alpha.2` | `2.0.0-alpha.1` <br/> `2.0.0-alpha.2` | `2.0.0.a1` <br/> `2.0.0.a2`   | `2.0.0-alpha.1` <br/> `2.0.0-alpha.2` | `2.0.0-alpha.1` <br/> `2.0.0-alpha.2` |
+| **DevPreview** | `2.0.0-rc.1` <br/> `2.0.0-rc.2`       | `2.0.0-rc.1` <br/> `2.0.0-rc.2`       | `2.0.0.rc1` <br/> `2.0.0.rc2` | `2.0.0-rc.1` <br/> `2.0.0-rc.2`       | `2.0.0-rc.1` <br/> `2.0.0-rc.2`       |
+| **GA**         | `2.0.0` <br/> `2.1.0`                 | `2.0.0` <br/> `2.1.0`                 | `2.0.0` <br/> `2.1.0`         | `2.0.0` <br/> `2.1.0`                 | `2.0.0` <br/> `2.1.0`                 |
 
 Besides the pre-releases suffix, NPM releases during the alpha and developer
 preview phases will also include a `v2` distribution tag. During these two
@@ -297,6 +297,7 @@ created to track the latest release of CDK `1.x.y`.
   https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#pre-release-versions
 [python packaging]:
   https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning
+[go versioning]: https://blog.golang.org/publishing-go-modules#TOC_3.
 
 ## Feature Implementation
 

--- a/text/0079-cdk-2.0.md
+++ b/text/0079-cdk-2.0.md
@@ -262,9 +262,9 @@ will naturally retain the ability to opt out of this feature.
 `aws-cdk-lib` will be released to the various package managers under the
 following package name.
 
-| Github & NPM  | Maven Central                | PyPI          | NuGet            |
-| ------------- | ---------------------------- | ------------- | ---------------- |
-| `aws-cdk-lib` | `software.amazon.awscdk.lib` | `aws-cdk-lib` | `Amazon.CDK.Lib` |
+| Github & NPM  | Maven Central                | PyPI          | NuGet            | Go                                 |
+| ------------- | ---------------------------- | ------------- | ---------------- |------------------------------------|
+| `aws-cdk-lib` | `software.amazon.awscdk.lib` | `aws-cdk-lib` | `Amazon.CDK.Lib` | `github.com/aws/aws-cdk-go/awscdk` |
 
 CDKv2 will be published in three phases - **alpha**, **release candidate** and
 finally **generally available**. During the first two phases, packages will be


### PR DESCRIPTION
As we prepare to release Go for 1.x and 2.x, add a section to the Monolithic Packaging RFC which proposes the naming strategy.


---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_
