### PR TITLE
RFC 6: record Python naming decisions

### DIFF
--- a/text/0006-monolothic-packaging.md
+++ b/text/0006-monolothic-packaging.md
@@ -251,14 +251,15 @@ using Amazon.CDK.AWS.S3;
 
 Package name:
 
-- **dist-name**: `aws-cdk-lib` or `aws-cdk`
-- **module name**: `aws_cdk` or `aws_cdk_lib` (to preserve current usage?)
+- **dist-name**: `aws-cdk-lib`
+- **module name**: `aws_cdk` (same as v1 to encourage easier migration)
 
 Usage:
 
 ```py
 from aws_cdk import (
-    core,
+    Stack,
+    Construct,
     aws_lambda,
     aws_dynamodb,
     aws_events,
@@ -270,14 +271,8 @@ Migration path:
 
 - All `aws-cdk.xxx` dependencies will be removed from `requirements.txt` and
   replaced with `aws-cdk-lib`.
-- No change in code usage, unless we decide to rename the module to
-  `aws_cdk_lib`.
-
-Open issues:
-
-- Should we use `aws-cdk-lib` or `aws-cdk` as the distName?
-- Should we use `aws_cdk` as the module name to preserve compatibility or rename
-  to `aws_cdk_lib`?
+- Classes that used to be imported from `aws_cdk.core` will now be imported from `aws_cdk`.
+- No other changes.
 
 ### Go
 

--- a/text/0006-monolothic-packaging.md
+++ b/text/0006-monolothic-packaging.md
@@ -209,15 +209,24 @@ Migration path:
 
 ### Java
 
-Package name:
+Maven package name:
 
 - **Group ID**: `software.amazon.awscdk`
 - **Artifact ID**: `aws-cdk-lib`
 
+Source:
+
+- **Package name**: `software.amazon.awscdk.*`
+  - We configure `software.amazon.awscdk.core` as module name in the root package
+    `aws-cdk-lib/package.json` for maximum compatibility with v1 class names
+    (as the classes previously in the `core` submodule have moved there). Doing
+    so will not negatively affect subpackages, which will still have their own
+    independent module names like `software.amazon.awscdk.services.s3`.
+
 Usage:
 
 ```java
-import software.amazon.awscdk.core.Stack; // hopefully (see "remaining work")
+import software.amazon.awscdk.core.Stack;
 import software.amazon.awscdk.services.ec2.Vpc;
 ```
 
@@ -226,12 +235,6 @@ Migration path:
 - Update `pom.xml` and replace all existing dependencies with the monolithic
   module.
 - No change required in source files
-
-Open issues:
-
-- Will core types will have to go under `software.amazon.awscdk` instead of
-  `software.amazon.awscdk.core`? This depends if submodule renaming will support
-  specifying the per-language names for the root module.
 
 ### .NET
 
@@ -252,14 +255,18 @@ using Amazon.CDK.AWS.S3;
 Package name:
 
 - **dist-name**: `aws-cdk-lib`
-- **module name**: `aws_cdk` (same as v1 to encourage easier migration)
+- **module name**: `aws_cdk`
+  - We configure `aws_cdk.core` as module name in the root package
+    `aws-cdk-lib/package.json` for maximum compatibility with v1 class names
+    (as the classes previously in the `core` submodule have moved there). Doing
+    so will not negatively affect subpackages, which will still have their own
+    independent module names like `aws_cdk.aws_s3`.
 
 Usage:
 
 ```py
 from aws_cdk import (
-    Stack,
-    Construct,
+    core,
     aws_lambda,
     aws_dynamodb,
     aws_events,
@@ -271,8 +278,7 @@ Migration path:
 
 - All `aws-cdk.xxx` dependencies will be removed from `requirements.txt` and
   replaced with `aws-cdk-lib`.
-- Classes that used to be imported from `aws_cdk.core` will now be imported from `aws_cdk`.
-- No other changes.
+- No other source changes.
 
 ### Go
 
@@ -465,14 +471,6 @@ General recommendations:
       report analytics at the construct level.
 - [ ] **Reference documentation** needs to also support submodules/namespaces
       and use the submodule's README file.
-- [ ] **Submodule renaming**: to preserve imports in some languages (i.e.
-      Java/.NET), we need to be able to explicitly specify the "coordinates" of
-      submodules in each language. For example, the S3 module is exported under
-      the `aws_s3` module in mono-cdk, but we want it's types to be defined
-      under the `software.amazon.awscdk.services.s3` Java package, so we need a
-      way to specify this mapping somehow. This might be a problem for the
-      "core" types which are exported without a submodule in the mono-cdk, but
-      in Java they are currently under `software.amazon.awscdk.core`.
 - [ ] Add module size protection during build.
 - [ ] Determine if we want to include the `-patterns` modules in monocdk or
       leave those as separate libraries (I lead towards separate libraries).

--- a/text/0006-monolothic-packaging.md
+++ b/text/0006-monolothic-packaging.md
@@ -194,6 +194,7 @@ Usage:
 ```ts
 // core imports
 import { Stack, App } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 // submodule imports
 import * as s3 from 'aws-cdk-lib/aws-s3';
@@ -206,6 +207,7 @@ Migration path:
 - Update `package.json` and remove all dependencies on `@aws-cdk/xyz` and add
   `aws-cdk-lib`.
 - Replace `"@aws-cdk"` with `"aws-cdk-lib"` in all source files.
+- Replace all references to `Construct`
 
 ### Java
 
@@ -228,13 +230,14 @@ Usage:
 ```java
 import software.amazon.awscdk.core.Stack;
 import software.amazon.awscdk.services.ec2.Vpc;
+import software.constructs.Construct;
 ```
 
 Migration path:
 
 - Update `pom.xml` and replace all existing dependencies with the monolithic
   module.
-- No change required in source files
+- All references to `Construct` will need to be changed to a new import.
 
 ### .NET
 
@@ -248,7 +251,12 @@ Usage:
 ```csharp
 using Amazon.CDK;
 using Amazon.CDK.AWS.S3;
+using Constructs;
 ```
+
+Migration path:
+
+- All references to `Construct` will need to be changed to a new import.
 
 ### Python
 
@@ -272,13 +280,14 @@ from aws_cdk import (
     aws_events,
     aws_events_targets,
 )
+from constructs import Construct
 ```
 
 Migration path:
 
 - All `aws-cdk.xxx` dependencies will be removed from `requirements.txt` and
   replaced with `aws-cdk-lib`.
-- No other source changes.
+- All references to `Construct` will need to be changed to a new import.
 
 ### Go
 

--- a/text/0079-cdk-2.0.md
+++ b/text/0079-cdk-2.0.md
@@ -262,9 +262,9 @@ will naturally retain the ability to opt out of this feature.
 `aws-cdk-lib` will be released to the various package managers under the
 following package name.
 
-| Github & NPM  | Maven Central                | PyPI          | NuGet            | Go                                 |
-| ------------- | ---------------------------- | ------------- | ---------------- |------------------------------------|
-| `aws-cdk-lib` | `software.amazon.awscdk.lib` | `aws-cdk-lib` | `Amazon.CDK.Lib` | `github.com/aws/aws-cdk-go/awscdk` |
+| Github & NPM  | Maven Central                        | PyPI          | NuGet            | Go                                 |
+| ------------- | ------------------------------------ | ------------- | ---------------- |------------------------------------|
+| `aws-cdk-lib` | `software.amazon.awscdk:aws-cdk-lib` | `aws-cdk-lib` | `Amazon.CDK.Lib` | `github.com/aws/aws-cdk-go/awscdk` |
 
 CDKv2 will be published in three phases - **alpha**, **release candidate** and
 finally **generally available**. During the first two phases, packages will be


### PR DESCRIPTION
Realize we may need to do some different work to not disturb Java/Python users (pretend the "root" package has the name of the old `core` package).

Also realize that "no source changes" is a pipe dream as long as the new `constructs` library is involved.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_
