### PR TITLE
chore: construct hub - doc generation in the backend

### DIFF
--- a/text/0314-cdk-construct-hub.md
+++ b/text/0314-cdk-construct-hub.md
@@ -372,7 +372,8 @@ The details of URLs to be configrued in CloudFront is available in [appendix
 
 #### Backend X Frontend Compatibility
 
-As described earlier, the front-end application consumes artifacts that are stored on the backend. Since these artifacts are subject to change, we need to define a mechanism by which the front-end is able to detect and operate on various versions of them.
+As described earlier, the front-end application consumes artifacts that are stored on the backend. Since these artifacts are subject to change,
+we need to define a mechanism by which the front-end is able to detect and operate on various versions of them.
 
 As a general guideline, we *prefer to show an older version, than to show nothing at all*.
 To be more concrete, older versions of the artifacts should still be available for consumption by older consumers.
@@ -393,9 +394,12 @@ Specicially, we describe how to implement this compatibility model for each type
 
 ##### Package Documentation
 
-Package documentation is created by the **Doc-Gen** function, which produces a JSON definition file: `packages/${assembly.name}/v${assembly.version}/docs-${lang}.v1.json`
+Package documentation is created by the **Doc-Gen** function, which produces a JSON definition file:
 
-Since the front-end fetches and parses this file, we'd like for it to operate on type safe interfaces that describe the schema. This will ensure that breaking changes will manifest as compile time errors, and force us to handle them.
+`packages/${assembly.name}/v${assembly.version}/docs-${lang}.v1.json`
+
+Since the front-end fetches and parses this file, we'd like for it to operate on type safe interfaces that describe the schema.
+This will ensure that breaking changes will manifest as compile time errors, and force us to handle them.
 
 To that end, we create a dedicated package, called `construct-hub-docgen`, which will define this schema, and provide an API to produce it.
 The version of the schema file will be derived from the major version of the package.
@@ -403,11 +407,13 @@ Every time a change is made to the schema, we automatically detect what type of 
 
 > This can be done by using either [json-schema-diff](https://www.npmjs.com/package/json-schema-diff), or [jsii-diff](https://github.com/aws/jsii/tree/main/packages/jsii-diff).
 
-If a breaking change is detected, we enforce that the next version to be released will include a major version bump. (i.e the commit was accompanied with a *BREAKING CHANGE:* notice)
+If a breaking change is detected, we enforce that the next version to be released will include a major version bump.
+(i.e the commit was accompanied with a *BREAKING CHANGE:* notice)
 
 > This can be done by storing the version prior to the bump, and comparing with the one after.
 
-Naturaly, every time a breaking change occurs, the front-end application will have to request and render a different schema file, while still maintaining support for all earlier versions.
+Naturaly, every time a breaking change occurs, the front-end application will have to request and render a different schema file,
+while still maintaining support for all earlier versions.
 
 To achieve this, we implement the following heristic in the front-end to fetch and render the appropriate version:
 

--- a/text/0314-cdk-construct-hub.md
+++ b/text/0314-cdk-construct-hub.md
@@ -296,7 +296,7 @@ detail pages.
      are immediately available as they packages are indexed.
 
   To ensure compatiblity between the schema of the definition, and the consuming
-  code (i.e the front-end application), the stored file will contain its version in the `version` feild of the schema.
+  code (i.e the front-end application), the stored file will contain its version in the `version` field of the schema.
 
   > For more information on this, see the [Backend X Frontend Compatiblity](#backend-x-frontend-compatibility) section.
 
@@ -419,8 +419,11 @@ If a breaking change is detected, we enforce that the next version to be release
 
 > This can be done by storing the version prior to the bump, and comparing with the one after.
 
-When a new major version of the schema is released, it is automatically picked up and deployed to the backend. Since the schema is overidden, this will break the front-end because the version supporting the new schema hasn't been deployed yet.
-We cannot afford this, which means we must enforce a deployment order in this scenario, by which the backend is deployed **only after** the front-end supporting it is deployed.
+When a new major version of the schema is released, it is automatically picked up and
+deployed to the backend. Since the schema is overidden, this will break the front-end
+because the version supporting the new schema hasn't been deployed yet.
+We cannot afford this, which means we must enforce a deployment order in this scenario,
+by which the backend is deployed **only after** the front-end supporting it is deployed.
 
 We can enforce this by employing the following mechanism:
 
@@ -429,12 +432,20 @@ We can enforce this by employing the following mechanism:
 
 When a new version of `construct-hub-docgen` is released (e.g `2.0.0`):
 
-- If the backend picks up this version first, the resolved version in the closure will be `2.0.0`. This will conflict with the version that the front-end requires, and thus fail at install time.
-- If the front-end picks up this version first, it will be updated and a new version will be released that depends on `2.0.0`. At this point, when backend dependencies are upgraded, both `construct-hub-docgen`, and the front-end itself are upgraded, which is the desired outcome.
+- If the backend picks up this version first, the resolved version in the closure
+will be `2.0.0`. This will conflict with the version that the front-end requires,
+and thus fail at install time.
+- If the front-end picks up this version first, it will be updated and a new version
+will be released that depends on `2.0.0`. At this point, when backend dependencies
+are upgraded, both `construct-hub-docgen`, and the front-end itself are upgraded,
+which is the desired outcome.
 
-> In addition, so that don't rely on `npm` behavior to reject this change, we can write a unit test that compares the schema version being used by the front-end, and compare it to the one being used by the backend, they have to match.
+> In addition, so that don't rely on `npm` behavior to reject this change,
+we can write a unit test that compares the schema version being used by the front-end,
+to the one being used by the backend, they have to match.
 
-This mechanism enforces that when the backend picks up a new version major of the schema, it will have to pick up a new version of the front-end that supports it.
+This mechanism enforces that when the backend picks up a new version major of the schema,
+it will have to pick up a new version of the front-end that supports it.
 
 From this point on, we just need to make sure we deploy the front-end first in the CDK application.
 

--- a/text/0314-cdk-construct-hub.md
+++ b/text/0314-cdk-construct-hub.md
@@ -409,7 +409,7 @@ Since the front-end fetches and parses this file, we'd like for it to operate on
 This will ensure that breaking changes will manifest as compile time errors, and force us to handle them.
 
 To that end, we create a dedicated package, called `construct-hub-docgen`, which will define this schema, and provide an API to produce it.
-The version of the schema file will be derived from the major version of the package.
+The version of the schema file will be the version of the package.
 Every time a change is made to the schema, we automatically detect what type of change has been made. (i.e breaking or not)
 
 > This can be done by using either [json-schema-diff](https://www.npmjs.com/package/json-schema-diff), or [jsii-diff](https://github.com/aws/jsii/tree/main/packages/jsii-diff).

--- a/text/0314-cdk-construct-hub.md
+++ b/text/0314-cdk-construct-hub.md
@@ -394,7 +394,7 @@ and include its major version in the `version` field of the schema:
 Every time a change in the artifact occurs, the contents of the artifact is replaced with the new version.
 Since artifacts are created in a long running background process, the new version
 may not be available immediately. This in turn means that at any given point in time,
-the artifact can either be in its new version, or an older one.
+the artifact can either be in its new version, or **any** of its older ones.
 
 As a general guideline, we *prefer displaying an older version of an artifact, than to display nothing at all.*.
 To that end, the front-end application will have to support displaying all versions of the artifact.
@@ -410,7 +410,7 @@ Package documentation is created by the **Doc-Gen** function, which produces a J
 Since the front-end fetches and parses this file, we'd like for it to operate on type safe interfaces that describe the schema.
 This will ensure that breaking changes will manifest as compile time errors, and force us to handle them.
 
-To that end, we create a dedicated package, called `construct-hub-docgen`, which will define this schema, and provide an API to produce it.
+To that end, we will extend [`jsii-docgen`](https://github.com/cdklabs/jsii-docgen) to define this schema, and provide an API to produce it.
 The version of the schema file will be the version of the package.
 Every time a change is made to the schema, we automatically detect what type of change has been made. (i.e breaking or not)
 
@@ -429,17 +429,17 @@ by which the backend is deployed **only after** the front-end supporting it is d
 
 We can enforce this by employing the following mechanism:
 
-- The front-end declares a `peerDepenedency` on `construct-hub-docgen`. (e.g `^1.0.0`)
-- The backend declares a `devDependency` on `construct-hub-docgen` (e.g `1.0.0`)
+- The front-end declares a `peerDepenedency` on `jsii-docgen`. (e.g `^1.0.0`)
+- The backend declares a `devDependency` on `jsii-docgen` (e.g `1.0.0`)
 
-When a new version of `construct-hub-docgen` is released (e.g `2.0.0`):
+When a new major version of `jsii-docgen` is released (e.g `2.0.0`):
 
 - If the backend picks up this version first, the resolved version in the closure
 will be `2.0.0`. This will conflict with the version that the front-end requires,
 and thus fail at install time.
 - If the front-end picks up this version first, it will be updated and a new version
 will be released that depends on `2.0.0`. At this point, when backend dependencies
-are upgraded, both `construct-hub-docgen`, and the front-end itself are upgraded,
+are upgraded, both `jsii-docgen`, and the front-end itself are upgraded,
 which is the desired outcome.
 
 > In addition, so that don't rely on `npm` behavior to reject this change,

--- a/text/0314-cdk-construct-hub.md
+++ b/text/0314-cdk-construct-hub.md
@@ -417,6 +417,8 @@ To achieve this, we implement the following heristic in the front-end to fetch a
 2. If doesn't exist yet, fetch earlier versions until success.
 3. Based on the fetched version, render the appropriate compoenent version.
 
+> Note that even though we support all versions, we only have to actively maintain the latest one.
+
 By implementing the above mechanism, we can freely push changes independantly to both front-end and backend, letting each of them deploy in its own cadence.
 
 #### Website Analytics

--- a/text/0314-cdk-construct-hub.md
+++ b/text/0314-cdk-construct-hub.md
@@ -295,10 +295,10 @@ detail pages.
      pre-compute transliterated assemblies for their libraries, so that these
      are immediately available as they packages are indexed.
 
-  To ensure compatiblity between the schema of the definition, and the consuming
-  code (i.e the front-end application), the stored file will contain its version in the `version` field of the schema.
+   To ensure compatiblity between the schema of the definition, and the consuming
+   code (i.e the front-end application), the stored file will contain its version in the `version` field of the schema.
 
-  > For more information on this, see the [Backend X Frontend Compatiblity](#backend-x-frontend-compatibility) section.
+   > For more information on this, see the [Backend X Frontend Compatiblity](#backend-x-frontend-compatibility) section.
 
 1. **Catalog Builder:** A Lambda function keeps the `catalog.json` object
    updated with the latest versions of each package's major version lines, which
@@ -392,7 +392,7 @@ and include its major version in the `version` field of the schema:
 ```
 
 Every time a change in the artifact occurs, the contents of the artifact is replaced with the new version.
-This means that at any given point in time, the artifact can either be in its new version, or the old one.
+Since artifacts are created in a long running background process, the new version may not be available immediately. This in turn means that at any given point in time, the artifact can either be in its new version, or an older one.
 
 As a general guideline, we *prefer displaying an older version of an artifact, than to display nothing at all.*.
 To that end, the front-end application will have to support displaying all versions of the artifact.

--- a/text/0314-cdk-construct-hub.md
+++ b/text/0314-cdk-construct-hub.md
@@ -303,9 +303,7 @@ detail pages.
 
   `packages/${assembly.name}/v${assembly.version}/docs-${lang}.v1.json`
 
-  > For more information on this, see the [Backend X Frontend Compatiblity] section.
-
-  [Backend X Frontend Compatiblity]: https://reactjs.org
+  > For more information on this, see the [Backend X Frontend Compatiblity](#backend-x-frontend-compatibility) section.
 
 1. **Catalog Builder:** A Lambda function keeps the `catalog.json` object
    updated with the latest versions of each package's major version lines, which

--- a/text/0314-cdk-construct-hub.md
+++ b/text/0314-cdk-construct-hub.md
@@ -392,7 +392,9 @@ and include its major version in the `version` field of the schema:
 ```
 
 Every time a change in the artifact occurs, the contents of the artifact is replaced with the new version.
-Since artifacts are created in a long running background process, the new version may not be available immediately. This in turn means that at any given point in time, the artifact can either be in its new version, or an older one.
+Since artifacts are created in a long running background process, the new version
+may not be available immediately. This in turn means that at any given point in time,
+the artifact can either be in its new version, or an older one.
 
 As a general guideline, we *prefer displaying an older version of an artifact, than to display nothing at all.*.
 To that end, the front-end application will have to support displaying all versions of the artifact.

--- a/text/0314-cdk-construct-hub.md
+++ b/text/0314-cdk-construct-hub.md
@@ -273,7 +273,7 @@ detail pages.
    will be notified once the information for a new package version is ready to
    be browsed.
 
-1. **Doc-Gen:** A Lambda function prepares language-specific documentation definition
+1. **Doc-Gen:** A series of Lambda functions prepare language-specific documentation definition
    files for each configured language, with adjusted naming conventions, and
    updated sample code fragments, and proceeds to store those at:
    `packages/${assembly.name}/v${assembly.version}/docs-${lang}.json`.
@@ -281,8 +281,6 @@ detail pages.
    the [jsii project][jsii], as well as custom code for generating language specific API references.
 
    [jsii]: https://aws.github.io/jsii
-
-   > Since documentation for each language can be generated in isolation, we can consider parallelizing this function in the future.
 
    - The **Doc-Gen** functions run asynchronously, and the documentation definition
      eventually becomes available. If the object is not available yet,
@@ -405,7 +403,7 @@ Every time a change is made to the schema, we automatically detect what type of 
 
 > This can be done by using either [json-schema-diff](https://www.npmjs.com/package/json-schema-diff), or [jsii-diff](https://github.com/aws/jsii/tree/main/packages/jsii-diff).
 
-If a breaking change is detected, we enforce that the next version to be released will include a major version bump. (i.e the commit was accompanied with a 'BREAKING CHANGE' notice)
+If a breaking change is detected, we enforce that the next version to be released will include a major version bump. (i.e the commit was accompanied with a *BREAKING CHANGE:* notice)
 
 > This can be done by storing the version prior to the bump, and comparing with the one after.
 

--- a/text/0314-cdk-construct-hub.md
+++ b/text/0314-cdk-construct-hub.md
@@ -447,7 +447,7 @@ export function render(version: number) {
 ```
 
 In this scenario, the latest major version is `2`, and the front-end supports both `1` and `2`.
-When major version `3` is introduced, `<PackageDocs>` is copied over to `<PackageDocs2>`, and `<PackageDocs>` is changed with the code to support major version `3`.
+When major version `3` is introduced, `<PackageDocs>` is copied over to `<PackageDocsV2>`, and `<PackageDocs>` is changed with the code to support major version `3`.
 
 ```ts
 export function render(version: number) {
@@ -464,7 +464,9 @@ export function render(version: number) {
 }
 ```
 
-With this mechanism, we only have to actively maintain the latest version of the `<PackageDocs>` component.
+This way, we only have to actively maintain the latest version of the `<PackageDocs>` component.
+
+By implementing the above mechanism, we can freely push changes to both front-end and backend, letting each of them deploy in its own independant cadence.
 
 #### Website Analytics
 


### PR DESCRIPTION
Introduce design modifications pertaining to generating package documentation artifacts in the backend as opposed to the front end. 

* [Rendered version](https://github.com/aws/aws-cdk-rfcs/blob/epolon/backend-goc-generation/text/0314-cdk-construct-hub.md)

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_
