### PR TITLE
RFC 353: Constructs for CloudFormation Extensions

### DIFF
--- a/text/353-cfn-registry-constructs.md
+++ b/text/353-cfn-registry-constructs.md
@@ -194,6 +194,8 @@ export class Cluster extends CfnResource {
   }
 }
 
+// ---------------- output of json2jsii:
+
 /**
  * A resource that creates Amazon Elastic Kubernetes Service (Amazon EKS) clusters.
  *
@@ -459,5 +461,4 @@ export interface KubernetesApiAccessEntry {
   readonly groups?: string[];
 
 }
-```
 ```

--- a/text/353-cfn-registry-constructs.md
+++ b/text/353-cfn-registry-constructs.md
@@ -16,7 +16,7 @@ makes it easier to use public CloudFormation extensions in your CDK apps.
 For example, let's say I want to define a GitHub repository using the `TF::GitHub::Repository` resource:
 
 ```ts
-import { Repository } from '@cdk-cloudformation-extensions/tf-github';
+import { Repository } from '@cdk-cloudformation-extensions/tf-github-repository';
 
 new Repository(this, 'MyRepo', {
   name: 'my-repo',
@@ -25,13 +25,14 @@ new Repository(this, 'MyRepo', {
 });
 ```
 
-For each namespace (e.g. `TF::GitHub` in the above example) in 
-the public CloudFormation Registry, a library is available under 
-the scope `@cdk-cloudformation-extensions/NAMESPACE`. This library
-includes construct libraries for all the types in that namespace.
+For each type (e.g. `TF::GitHub::Repository` in the above example) in 
+the public CloudFormation Registry, a module is available under 
+the scope `@cdk-cloudformation-extensions/NAMESPACE-TYPE`. This library
+includes a construct class and all the relevant data types for this
+type.
 
-New versions of all modules are released daily and include the 
-latest versions of all constructs.
+The module version corresponds to the version of the type schema
+in the public registry.
 
 ---
 

--- a/text/353-cfn-registry-constructs.md
+++ b/text/353-cfn-registry-constructs.md
@@ -9,14 +9,14 @@ resources and modules published to the public CloudFormation Registry.
 
 ## README
 
-The `@cdk-cloudformation-extensions/xxx` scope includes construct libraries with generated strongly-typed "L1" constructs
+The `@cdk-cloudformation-types/xxx` scope includes construct libraries with generated strongly-typed "L1" constructs
 for all the public extensions (resources and modules) in the AWS CloudFormation public registry. This library
 makes it easier to use public CloudFormation extensions in your CDK apps.
 
 For example, let's say I want to define a GitHub repository using the `TF::GitHub::Repository` resource:
 
 ```ts
-import { CfnRepository } from '@cdk-cloudformation-extensions/tf-github-repository';
+import { CfnRepository } from '@cdk-cloudformation-types/tf-github-repository';
 
 new CfnRepository(this, 'MyRepo', {
   name: 'my-repo',
@@ -27,7 +27,7 @@ new CfnRepository(this, 'MyRepo', {
 
 For each type (e.g. `TF::GitHub::Repository` in the above example) in
 the public CloudFormation Registry, a module is available under
-the scope `@cdk-cloudformation-extensions/NAMESPACE-TYPE`. This library
+the scope `@cdk-cloudformation-types/<namespace-type>`. This library
 includes a construct class and all the relevant data types for this
 type.
 
@@ -70,13 +70,13 @@ new CfnResource(this, 'MyEksCluster', {
 });
 ```
 
-With `@cdk-cloudformation-extensions` all public resources and modules will be listed in the **Construct Hub** like any
+With `@cdk-cloudformation-types` all public resources and modules will be listed in the **Construct Hub** like any
 other construct and by importing the relevant `cdk-cloudformation-extensions` module into their projects, they will be able to
 use them via strongly-typed classes. IDEs will show type information and inline help derived from the
 extension schema.
 
 ```ts
-import { CfnCluster } from '@cdk-cloudformation-extensions/awsqs-eks-cluster';
+import { CfnCluster } from '@cdk-cloudformation-types/awsqs-eks-cluster';
 
 new CfnCluster(this, 'MyEksCluster', {
   name: 'my-new-cluster',
@@ -146,19 +146,24 @@ We will use the following naming scheme:
   * .NET Namespace: `Cdklabs.CdkCloudFormationTypes.<NamePascalCase>` (e.g. `Cdklabs.CdkCloudFormationTypes.MongodbAtlasProject`)
 
 Alternatives:
-* `@cdk-types/mongodb-atlas-project`
-* `@cdk-cfn/mongodb-atlas-project`
-* `@cdkcfn/mongodb-atlas-project`
-* `@awscdk/mongodb-atlas-project`
-* `@cfn/mongodb-atlas-project`
-* `@cfn/cdk-mongodb-atlas-project`
-* `@cloudformation/cdk-mongodb-atlas-project`
-* `@cfntypes/mongodb-atlas-project`
-* `@cloudformation-registry/mongodb-atlas-project`
-* `@cfn-registry/cdk-mongodb-atlas-project`
-* `@cfn-types/cdk-mongodb-atlas-project`
-
-
+1. `@cdk-types/mongodb-atlas-project`
+2. `@cdk-cfn/mongodb-atlas-project`
+3. `@cdkcfn/mongodb-atlas-project`
+4. `@awscdk/mongodb-atlas-project`
+5. `@cfn/mongodb-atlas-project`
+6. `@cfn/cdk-mongodb-atlas-project`
+7. `@cloudformation/cdk-mongodb-atlas-project`
+8. `@cfntypes/mongodb-atlas-project`
+9. `@cloudformation-registry/mongodb-atlas-project`
+10. `@cfn-registry/cdk-mongodb-atlas-project`
+11. `@cfn-types/cdk-mongodb-atlas-project`
+12. `@cfn-registry/cdk-mongodb-atlas-project`
+13. `@cloudformation-registry/cdk-mongodb-atlas-project`
+13. `@cdk-cloudformation-registry/cdk-mongodb-atlas-project`
+13. `@cdk-resources/cdk-mongodb-atlas-project`
+13. `@awscdk-resources/mongodb-atlas-project`
+13. `@cloudformation-resources/mongodb-atlas-project`
+13. `@cloudformation-types/mongodb-atlas-project`
 
 #### Versioning
 

--- a/text/353-cfn-registry-constructs.md
+++ b/text/353-cfn-registry-constructs.md
@@ -137,8 +137,8 @@ that these modules include L1s which we also refer to as "CFN resources" in the 
   * Distribution name: `cdk-cloudformation-<name-kebab-case>` (e.g. `cdk-cloudformation-mongodb-atlas-project`)
   * Module: `cdk_cloudformation_<name_snake_case>` (e.g. `cdk_cloudformation_mongodb_atlas_project`)
 * **NuGet**:
-  * Package ID: `Cdklabs.CdkCloudFormation.<NamePascalCase>` (e.g. `Cdklabs.CdkCloudFormation.MongodbAtlasProject`)
-  * .NET Namespace: `Cdklabs.CdkCloudFormation.<NamePascalCase>` (e.g. `Cdklabs.CdkCloudFormation.MongodbAtlasProject`)
+  * Package ID: `CdkCloudFormation.<NamePascalCase>` (e.g. `CdkCloudFormation.MongodbAtlasProject`)
+  * .NET Namespace: `CdkCloudFormation.<NamePascalCase>` (e.g. `CdkCloudFormation.MongodbAtlasProject`)
 
 Alternatives considered:
 1. `@cdk-cloudformation-types/mongodb-atlas-project`

--- a/text/353-cfn-registry-constructs.md
+++ b/text/353-cfn-registry-constructs.md
@@ -207,6 +207,6 @@ version of the resource they use, we determined that the best approach is to pub
 
 ### Are there any open issues that need to be addressed later?
 
-* __Property name conversion__: `json2jsii` converts field names to camelCase to adhere with naming typescript naming conventions.
+* ~__Property name conversion__~ (resolved by [cdklabs/json2jsii#480](https://github.com/cdklabs/json2jsii/pull/480)): `json2jsii` converts field names to camelCase to adhere with naming typescript naming conventions.
   This means that we need to map field names back when we define the `CfnResource`. I think we might want to add a
   feature to `json2jsii` that will generate conversion functions that can be used to convert back data types to the original schema.

--- a/text/353-cfn-registry-constructs.md
+++ b/text/353-cfn-registry-constructs.md
@@ -4,29 +4,29 @@
 * **Tracking Issue**: #353
 * **API Bar Raiser**: @rix0rrr
 
-A set of construct libraries which includes generated constructs for all CloudFormation 
+A set of construct libraries which includes generated constructs for all CloudFormation
 resources and modules published to the public CloudFormation Registry.
 
 ## README
 
-The `@cdk-cloudformation-extensions/xxx` construct libraries includes generated strongly-typed "L1" constructs 
+The `@cdk-cloudformation-extensions/xxx` scope includes construct libraries with generated strongly-typed "L1" constructs
 for all the public extensions (resources and modules) in the AWS CloudFormation public registry. This library
 makes it easier to use public CloudFormation extensions in your CDK apps.
 
 For example, let's say I want to define a GitHub repository using the `TF::GitHub::Repository` resource:
 
 ```ts
-import { Repository } from '@cdk-cloudformation-extensions/tf-github-repository';
+import { CfnRepository } from '@cdk-cloudformation-extensions/tf-github-repository';
 
-new Repository(this, 'MyRepo', {
+new CfnRepository(this, 'MyRepo', {
   name: 'my-repo',
   description: 'My awesome project',
   licenseTemplate: 'apache-2.0',
 });
 ```
 
-For each type (e.g. `TF::GitHub::Repository` in the above example) in 
-the public CloudFormation Registry, a module is available under 
+For each type (e.g. `TF::GitHub::Repository` in the above example) in
+the public CloudFormation Registry, a module is available under
 the scope `@cdk-cloudformation-extensions/NAMESPACE-TYPE`. This library
 includes a construct class and all the relevant data types for this
 type.
@@ -48,7 +48,7 @@ RFC pull request):
 
 ### What are we launching today?
 
-We are publishing a set of construct libraries (in all JSII languages) which include constructs (and auxiliary types) for 
+We are publishing a set of construct libraries (in all JSII languages) which include constructs (and auxiliary types) for
 all the resources and modules in the public CloudFormation registry.
 
 ### Why should I use this feature?
@@ -76,9 +76,9 @@ use them via strongly-typed classes. IDEs will show type information and inline 
 extension schema.
 
 ```ts
-import { Cluster } from '@cdk-cloudformation-extensions/awsqs-eks';
+import { CfnCluster } from '@cdk-cloudformation-extensions/awsqs-eks-cluster';
 
-new Cluster(this, 'MyEksCluster', {
+new CfnCluster(this, 'MyEksCluster', {
   name: 'my-new-cluster',
   tags: [ { key: 'foo', value: 'bar' } ],
 });
@@ -88,7 +88,7 @@ new Cluster(this, 'MyEksCluster', {
 
 ### Why are we doing this?
 
-We are doing this because CDK users would like to be able to use CloudFormation extensions 
+We are doing this because CDK users would like to be able to use CloudFormation extensions
 (modules, resources) as first-class citizens in CDK code. Extensions and native resource types
 should look and feel the same way when defined in CDK apps.
 
@@ -98,23 +98,37 @@ extensions, this library will naturally be discoverable through the Hub.
 
 ### Why should we _not_ do this?
 
-We have a longer term plan ([RFC#77](https://github.com/aws/aws-cdk-rfcs/issues/77)) to add 
+We have a longer term plan ([RFC#77](https://github.com/aws/aws-cdk-rfcs/issues/77)) to add
 support for a CLI command called `cdk import` which will allow users to generate L1s from any
 registry type just-in-type and add them to their project (this is similar to CDK8s and CDKtf).
 
 ### What is the technical solution (design) of this feature?
 
-The idea is to do something similar to what we do with the CloudFormation L1s 
-in the AWS CDK and simply publish JSII construct libraries which includes 
+The idea is to do something similar to what we do with the CloudFormation L1s
+in the AWS CDK and simply publish JSII construct libraries which includes
 statically-generated L1s for all the public registry extensions.
 
-#### Library per type
+#### Package per type
 
 CloudFormation extensions are semantically versioned. This means that new versions of an extension
 may include breaking changes. We also want to allow users to pick up a specific version of an extension.
-In light of these constraints, we determined that the best path forward is to publish each extension
+In light of these constraints, we determined that the best path forward is to publish each extension (type)
 as a separate module, with a version that corresponds to the extension version in the CloudFormation
 registry. This way, we will have 1:1 alignment and users will have the most freedom.
+
+There are currently 44 public types (resources & modules), but we expect this
+list to substantially grow. If this dramatically scales (to thousands of
+packages) and we hit any limitations of package managers (e.g. account/scope
+limits), we can shard the solution (multiple accounts, multiple scopes, etc).
+
+#### Versioning
+
+To allow users to select which extension schema version to use, the version of
+each package will be based on the schema version of the extension.
+
+We will prefer to use the full schema version (MAJOR.MINOR.PATCH), but if we
+will need to publish a security patch, we should be able to bump the PATCH
+number as needed.
 
 #### Code Generator
 
@@ -122,13 +136,16 @@ The code generator will be executed daily (e.g. through a GitHub workflow),
 query the CloudFormation Registry, and generate L1s for all the types based
 on their metadata and schema.
 
-We can use the `ListTypes` API to list all the types in the registry:
+The code generator will be implemented as a separate tool called
+[`cdk-import`](https://github.com/cdklabs/cdk-import).
+
+We can use the `ListTypes` API to list all the types in the registry (excluding native AWS resources):
 
 ```shell
-aws cloudformation list-types --visibility=PUBLIC
+aws cloudformation list-types --visibility=PUBLIC | grep -v "AWS::"
 ```
 
-And then for each type, we can use `DescribeType` to retrieve the type information and its schema. 
+And then for each type, we can use `DescribeType` to retrieve the type information and its schema.
 
 For example, this command will return the description of the `AWSQS::EKS::Cluster` resource:
 
@@ -136,18 +153,17 @@ For example, this command will return the description of the `AWSQS::EKS::Cluste
 aws cloudformation describe-type --arn arn:aws:cloudformation:us-east-1::type/resource/408988dff9e863704bcc72e7e13f8d645cee8311/AWSQS-EKS-Cluster
 ```
 
-For reference: the output of this command can be found [here](https://gist.github.com/eladb/bf417c07444027d6954360295df4ee37#file-awsqs-vpc-vpcqs-module-json). 
+For reference: the output of this command can be found [here](https://gist.github.com/eladb/bf417c07444027d6954360295df4ee37#file-awsqs-vpc-vpcqs-module-json).
 The parsed `Schema` field can be found [here](https://gist.github.com/eladb/bf417c07444027d6954360295df4ee37#file-awsqs-vpc-vpcqs-module-schema-json).
 
-Now, we need to filter all non-`AWS::` types (the `AWS::` types are actually L1s), and then generate 
+Now, we need to filter all non-`AWS::` types (the `AWS::` types are actually L1s), and then generate
 an L1 construct for each one. This includes:
 
-1. Generating the construct class that extends `CfnResource`. I think we can use submodules to 
+1. Generating the construct class that extends `CfnResource`. I think we can use submodules to
    represent the type namespace (`awsqs.eks` in this case), and the name of the resource as the construct name `Cluster`.
-2. Generate an `XxxProps` JSII struct for this construct based on the `Schema` field. 
-   This can be done using [`json2jsii`](https://github.com/cdklabs/json2jsii), which is the same 
+2. Generate an `XxxProps` JSII struct for this construct based on the `Schema` field.
+   This can be done using [`json2jsii`](https://github.com/cdklabs/json2jsii), which is the same
    tool we use to implemented the `import` command in CDK8s and CDKtf.
-
 
 ### Is this a breaking change?
 
@@ -161,307 +177,36 @@ Nope.
 
 #### `cdk import` versus library
 
-As mentioned above, an alternative approach would be to add support for `import` in the CDK CLI. The downsides of this approach (at this point) 
-are that (a) it is a bigger investment as it involves a change to the CDK CLI; and (b) the Construct Hub won't be able to surface these
-types automatically (we will need some custom support for "imported" types, which is something that we would like to add to the Construct Hub
-in the future for all CDK domains).
+As mentioned above, an alternative approach would be to add support for `import`
+in the CDK CLI, which is inline with how other CDKs implement this functionality
+(`import` in CDK8s and `get` in CDKtf). The `import` experience offers a "just
+in time" option that the pre-published library option does not, but also
+increases the cognitive load for users since they will need to understand how
+`import` works.
+
+The downsides of the `import` approach (at this point) are that (a) it is a
+bigger investment as it involves a change to the CDK CLI; and (b) the Construct
+Hub won't be able to surface these types automatically (we will need some custom
+support for "imported" types, which is something that we would like to add to
+the Construct Hub in the future for all CDK domains).
+
+To make sure this path is possible in the future, the code generator will be
+implemented as a separate tool called `cdk-import`, which we can later integrate
+into the CDK CLI.
 
 #### Monolithic versus module per resource
 
 As mentioned above, due to the fact that resource schemas are versioned and we want to allow users to select which
-version of the resource they use, we determined that the best approach is to publish a module for each resource.
-This has logicical/operational implications that we believe can mostly be mitigated using projen's capabilities to
-reason about the project structure and publishing workflows using code.
+version of the resource they use, we determined that the best approach is to publish a generated module for each resource.
 
 ### What is the high level implementation plan?
 
-- [ ] Implement [`cdk-import`](https://github.com/cdklabs/cdk-import) as a command-line tool that generates L1 constructs for registry extensions.
-- [ ] Create a mono-repo-style project using projen that utilizes `cdk-import` to generate a module for each registry resource.
-
+* [ ] Implement [`cdk-import`](https://github.com/cdklabs/cdk-import) as a command-line tool that generates L1 constructs for registry extensions.
+* [ ] Create a mono-repo-style project using projen that utilizes `cdk-import` to generate a module for each registry resource.
+* [ ] Created a scheduled job which generates the modules periodically (should probably run against `us-east-1`)
 
 ### Are there any open issues that need to be addressed later?
 
-* __Property name conversion__: `json2jsii` converts field names to camelCase to adhere with naming typescript naming conventions. 
-  This means that we need to map field names back when we define the `CfnResource`. I think we might want to add a 
+* __Property name conversion__: `json2jsii` converts field names to camelCase to adhere with naming typescript naming conventions.
+  This means that we need to map field names back when we define the `CfnResource`. I think we might want to add a
   feature to `json2jsii` that will generate conversion functions that can be used to convert back data types to the original schema.
-
-## Appendix
-
-```ts
-export class Cluster extends CfnResource {
-  constructor(scope: Construct, id: string, props: ClusterProps) {
-    super(scope, id, {
-      type: 'AWSQS::EKS::Cluster',
-      properties: capitalize(props),
-    });
-  }
-}
-
-// ---------------- output of json2jsii:
-
-/**
- * A resource that creates Amazon Elastic Kubernetes Service (Amazon EKS) clusters.
- *
- * @schema ClusterProps
- */
-export interface ClusterProps {
-  /**
-   * A unique name for your cluster.
-   *
-   * @schema ClusterProps#Name
-   */
-  readonly name?: string;
-
-  /**
-   * Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role. This provides permissions for Amazon EKS to call other AWS APIs.
-   *
-   * @schema ClusterProps#RoleArn
-   */
-  readonly roleArn?: string;
-
-  /**
-   * Name of the AWS Identity and Access Management (IAM) role used for clusters that have the public endpoint disabled. this provides permissions for Lambda to be invoked and attach to the cluster VPC
-   *
-   * @schema ClusterProps#LambdaRoleName
-   */
-  readonly lambdaRoleName?: string;
-
-  /**
-   * Desired Kubernetes version for your cluster. If you don't specify this value, the cluster uses the latest version from Amazon EKS.
-   *
-   * @schema ClusterProps#Version
-   */
-  readonly version?: string;
-
-  /**
-   * Network configuration for Amazon EKS cluster.
-
-
-   *
-   * @schema ClusterProps#KubernetesNetworkConfig
-   */
-  readonly kubernetesNetworkConfig?: ClusterPropsKubernetesNetworkConfig;
-
-  /**
-   * An object that represents the virtual private cloud (VPC) configuration to use for an Amazon EKS cluster.
-   *
-   * @schema ClusterProps#ResourcesVpcConfig
-   */
-  readonly resourcesVpcConfig?: ClusterPropsResourcesVpcConfig;
-
-  /**
-   * Enables exporting of logs from the Kubernetes control plane to Amazon CloudWatch Logs. By default, logs from the cluster control plane are not exported to CloudWatch Logs. The valid log types are api, audit, authenticator, controllerManager, and scheduler.
-   *
-   * @schema ClusterProps#EnabledClusterLoggingTypes
-   */
-  readonly enabledClusterLoggingTypes?: string[];
-
-  /**
-   * Encryption configuration for the cluster.
-   *
-   * @schema ClusterProps#EncryptionConfig
-   */
-  readonly encryptionConfig?: EncryptionConfigEntry[];
-
-  /**
-   * @schema ClusterProps#KubernetesApiAccess
-   */
-  readonly kubernetesApiAccess?: ClusterPropsKubernetesApiAccess;
-
-  /**
-   * ARN of the cluster (e.g., `arn:aws:eks:us-west-2:666666666666:cluster/prod`).
-   *
-   * @schema ClusterProps#Arn
-   */
-  readonly arn?: string;
-
-  /**
-   * Certificate authority data for your cluster.
-   *
-   * @schema ClusterProps#CertificateAuthorityData
-   */
-  readonly certificateAuthorityData?: string;
-
-  /**
-   * Security group that was created by Amazon EKS for your cluster. Managed-node groups use this security group for control-plane-to-data-plane communications.
-   *
-   * @schema ClusterProps#ClusterSecurityGroupId
-   */
-  readonly clusterSecurityGroupId?: string;
-
-  /**
-   * Endpoint for your Kubernetes API server (e.g., https://5E1D0CEXAMPLEA591B746AFC5AB30262.yl4.us-west-2.eks.amazonaws.com).
-   *
-   * @schema ClusterProps#Endpoint
-   */
-  readonly endpoint?: string;
-
-  /**
-   * ARN or alias of the customer master key (CMK).
-   *
-   * @schema ClusterProps#EncryptionConfigKeyArn
-   */
-  readonly encryptionConfigKeyArn?: string;
-
-  /**
-   * Issuer URL for the OpenID Connect identity provider.
-   *
-   * @schema ClusterProps#OIDCIssuerURL
-   */
-  readonly oidcIssuerUrl?: string;
-
-  /**
-   * @schema ClusterProps#Tags
-   */
-  readonly tags?: ClusterPropsTags[];
-
-}
-
-/**
- * Network configuration for Amazon EKS cluster.
-
-
- *
- * @schema ClusterPropsKubernetesNetworkConfig
- */
-export interface ClusterPropsKubernetesNetworkConfig {
-  /**
-   * Specify the range from which cluster services will receive IPv4 addresses.
-   *
-   * @schema ClusterPropsKubernetesNetworkConfig#ServiceIpv4Cidr
-   */
-  readonly serviceIpv4Cidr?: string;
-
-}
-
-/**
- * An object that represents the virtual private cloud (VPC) configuration to use for an Amazon EKS cluster.
- *
- * @schema ClusterPropsResourcesVpcConfig
- */
-export interface ClusterPropsResourcesVpcConfig {
-  /**
-   * Specify one or more security groups for the cross-account elastic network interfaces that Amazon EKS creates to use to allow communication between your worker nodes and the Kubernetes control plane. If you don't specify a security group, the default security group for your VPC is used.
-   *
-   * @schema ClusterPropsResourcesVpcConfig#SecurityGroupIds
-   */
-  readonly securityGroupIds?: string[];
-
-  /**
-   * Specify subnets for your Amazon EKS worker nodes. Amazon EKS creates cross-account elastic network interfaces in these subnets to allow communication between your worker nodes and the Kubernetes control plane.
-   *
-   * @schema ClusterPropsResourcesVpcConfig#SubnetIds
-   */
-  readonly subnetIds?: string[];
-
-  /**
-   * Set this value to false to disable public access to your cluster's Kubernetes API server endpoint. If you disable public access, your cluster's Kubernetes API server can only receive requests from within the cluster VPC. The default value for this parameter is true , which enables public access for your Kubernetes API server.
-   *
-   * @schema ClusterPropsResourcesVpcConfig#EndpointPublicAccess
-   */
-  readonly endpointPublicAccess?: boolean;
-
-  /**
-   * Set this value to true to enable private access for your cluster's Kubernetes API server endpoint. If you enable private access, Kubernetes API requests from within your cluster's VPC use the private VPC endpoint. The default value for this parameter is false , which disables private access for your Kubernetes API server. If you disable private access and you have worker nodes or AWS Fargate pods in the cluster, then ensure that publicAccessCidrs includes the necessary CIDR blocks for communication with the worker nodes or Fargate pods.
-   *
-   * @schema ClusterPropsResourcesVpcConfig#EndpointPrivateAccess
-   */
-  readonly endpointPrivateAccess?: boolean;
-
-  /**
-   * The CIDR blocks that are allowed access to your cluster's public Kubernetes API server endpoint. Communication to the endpoint from addresses outside of the CIDR blocks that you specify is denied. The default value is 0.0.0.0/0 . If you've disabled private endpoint access and you have worker nodes or AWS Fargate pods in the cluster, then ensure that you specify the necessary CIDR blocks.
-   *
-   * @schema ClusterPropsResourcesVpcConfig#PublicAccessCidrs
-   */
-  readonly publicAccessCidrs?: string[];
-
-}
-
-/**
- * The encryption configuration for the cluster.
- *
- * @schema EncryptionConfigEntry
- */
-export interface EncryptionConfigEntry {
-  /**
-   * Specifies the resources to be encrypted. The only supported value is "secrets".
-   *
-   * @schema EncryptionConfigEntry#Resources
-   */
-  readonly resources?: string[];
-
-  /**
-   * @schema EncryptionConfigEntry#Provider
-   */
-  readonly provider?: Provider;
-
-}
-
-/**
- * @schema ClusterPropsKubernetesApiAccess
- */
-export interface ClusterPropsKubernetesApiAccess {
-  /**
-   * @schema ClusterPropsKubernetesApiAccess#Roles
-   */
-  readonly roles?: KubernetesApiAccessEntry[];
-
-  /**
-   * @schema ClusterPropsKubernetesApiAccess#Users
-   */
-  readonly users?: KubernetesApiAccessEntry[];
-
-}
-
-/**
- * @schema ClusterPropsTags
- */
-export interface ClusterPropsTags {
-  /**
-   * @schema ClusterPropsTags#Value
-   */
-  readonly value?: string;
-
-  /**
-   * @schema ClusterPropsTags#Key
-   */
-  readonly key?: string;
-
-}
-
-/**
- * AWS Key Management Service (AWS KMS) customer master key (CMK). Either the ARN or the alias can be used.
- *
- * @schema Provider
- */
-export interface Provider {
-  /**
-   * Amazon Resource Name (ARN) or alias of the customer master key (CMK). The CMK must be symmetric, created in the same region as the cluster, and if the CMK was created in a different account, the user must have access to the CMK.
-   *
-   * @schema Provider#KeyArn
-   */
-  readonly keyArn?: string;
-
-}
-
-/**
- * @schema KubernetesApiAccessEntry
- */
-export interface KubernetesApiAccessEntry {
-  /**
-   * @schema KubernetesApiAccessEntry#Arn
-   */
-  readonly arn?: string;
-
-  /**
-   * @schema KubernetesApiAccessEntry#Username
-   */
-  readonly username?: string;
-
-  /**
-   * @schema KubernetesApiAccessEntry#Groups
-   */
-  readonly groups?: string[];
-
-}
-```

--- a/text/353-cfn-registry-constructs.md
+++ b/text/353-cfn-registry-constructs.md
@@ -2,7 +2,7 @@
 
 * **Original Author(s):**: @eladb
 * **Tracking Issue**: #353
-* **API Bar Raiser**: TBD
+* **API Bar Raiser**: @rix0rrr
 
 A set of construct libraries which includes generated constructs for all CloudFormation 
 resources and modules published to the public CloudFormation Registry.
@@ -175,7 +175,9 @@ reason about the project structure and publishing workflows using code.
 
 ### What is the high level implementation plan?
 
-TBD
+- [ ] Implement [`cdk-import`](https://github.com/cdklabs/cdk-import) as a command-line tool that generates L1 constructs for registry extensions.
+- [ ] Create a mono-repo-style project using projen that utilizes `cdk-import` to generate a module for each registry resource.
+
 
 ### Are there any open issues that need to be addressed later?
 

--- a/text/353-cfn-registry-constructs.md
+++ b/text/353-cfn-registry-constructs.md
@@ -121,6 +121,45 @@ list to substantially grow. If this dramatically scales (to thousands of
 packages) and we hit any limitations of package managers (e.g. account/scope
 limits), we can shard the solution (multiple accounts, multiple scopes, etc).
 
+#### Naming Scheme
+
+> *This is still not finalized. From a CDK user standpoint, I am not sure if they should really
+> care if these are CloudFormation registry extensions or just normal CDK libraries. Consider a user
+> that goes to Construct Hub and searches for "mongodb". They find this library, import it and use it.
+> As far as they are concerned, they just used a construct library. The fact that this is an L1 type
+> and not some L2/L3 is an implementation details, isn't it. So I am not sure that the semantics which
+> involves "CloudFormation" or "extensions" or "types" is not a leak in the abstraction*.
+
+We will use the following naming scheme:
+
+* **npm**: 
+  * Package name: `@cdk-cloudformation-types/<name-kebab-case>` (e.g. `cdk-cloudformation-types/mongodb-atlas-project`)
+* **Maven Central**:
+  * Group ID: `io.github.cdklabs.cdk_cloudformation_types`
+  * Artifact ID: `<name-kebab-case>` (e.g. `mongodb-atlas-project`)
+  * Java Package: `io.github.cdklabs.cdk_cloudformation_types.<name_snake_case>` (e.g. `io.github.cdklabs.cdk_cloudformation.mongodb_atlas_project`)
+* **PyPI**:
+  * Distribution name: `cdk-cloudformation-types-<name-kebab-case>` (e.g. `cdk-cloudformation-types-mongodb-atlas-project`)
+  * Module: `cdk_cloudformation_types_<name_snake_case>` (e.g. `cdk_cloudformation_types_mongodb_atlas_project`)
+* **NuGet**:
+  * Package ID: `Cdklabs.CdkCloudFormationTypes.<NamePascalCase>` (e.g. `Cdklabs.CdkCloudFormationTypes.MongodbAtlasProject`)
+  * .NET Namespace: `Cdklabs.CdkCloudFormationTypes.<NamePascalCase>` (e.g. `Cdklabs.CdkCloudFormationTypes.MongodbAtlasProject`)
+
+Alternatives:
+* `@cdk-types/mongodb-atlas-project`
+* `@cdk-cfn/mongodb-atlas-project`
+* `@cdkcfn/mongodb-atlas-project`
+* `@awscdk/mongodb-atlas-project`
+* `@cfn/mongodb-atlas-project`
+* `@cfn/cdk-mongodb-atlas-project`
+* `@cloudformation/cdk-mongodb-atlas-project`
+* `@cfntypes/mongodb-atlas-project`
+* `@cloudformation-registry/mongodb-atlas-project`
+* `@cfn-registry/cdk-mongodb-atlas-project`
+* `@cfn-types/cdk-mongodb-atlas-project`
+
+
+
 #### Versioning
 
 To allow users to select which extension schema version to use, the version of
@@ -136,7 +175,7 @@ The code generator will be executed daily (e.g. through a GitHub workflow),
 query the CloudFormation Registry, and generate L1s for all the types based
 on their metadata and schema.
 
-The code generator will be implemented as a separate tool called
+The code generator is implemented as a separate tool called
 [`cdk-import`](https://github.com/cdklabs/cdk-import).
 
 We can use the `ListTypes` API to list all the types in the registry (excluding native AWS resources):
@@ -174,6 +213,7 @@ Nope.
 > Describe any problems/risks that can be introduced if we implement this RFC.
 
 ### What alternative solutions did you consider?
+
 
 #### `cdk import` versus library
 

--- a/text/353-cfn-registry-constructs.md
+++ b/text/353-cfn-registry-constructs.md
@@ -1,0 +1,463 @@
+# {RFC_TITLE}
+
+* **Original Author(s):**: @eladb
+* **Tracking Issue**: #353
+* **API Bar Raiser**: TBD
+
+A set of construct libraries which includes generated constructs for all CloudFormation 
+resources and modules published to the public CloudFormation Registry.
+
+## README
+
+The `@cdk-cloudformation-extensions/xxx` construct libraries includes generated strongly-typed "L1" constructs 
+for all the public extensions (resources and modules) in the AWS CloudFormation public registry. This library
+makes it easier to use public CloudFormation extensions in your CDK apps.
+
+For example, let's say I want to define a GitHub repository using the `TF::GitHub::Repository` resource:
+
+```ts
+import { Repository } from '@cdk-cloudformation-extensions/tf-github';
+
+new Repository(this, 'MyRepo', {
+  name: 'my-repo',
+  description: 'My awesome project',
+  licenseTemplate: 'apache-2.0',
+});
+```
+
+For each namespace (e.g. `TF::GitHub` in the above example) in 
+the public CloudFormation Registry, a library is available under 
+the scope `@cdk-cloudformation-extensions/NAMESPACE`. This library
+includes construct libraries for all the types in that namespace.
+
+New versions of all modules are released daily and include the 
+latest versions of all constructs.
+
+---
+
+Ticking the box below indicates that the public API of this RFC has been
+signed-off by the API bar raiser (the `api-approved` label was applied to the
+RFC pull request):
+
+```
+[ ] Signed-off by API Bar Raiser @xxxxx
+```
+
+## Public FAQ
+
+### What are we launching today?
+
+We are publishing a set of construct libraries (in all JSII languages) which include constructs (and auxiliary types) for 
+all the resources and modules in the public CloudFormation registry.
+
+### Why should I use this feature?
+
+This library makes it easier to discover and use CloudFormation extensions in CDK apps.
+
+Previously, in order to use a resource from the CloudFormation registry, you would need to look up the resource documentation
+and use the low-level, weakly-typed `CfnResource` class to define it in your CDK app:
+
+```ts
+new CfnResource(this, 'MyEksCluster', {
+  type: 'AWSQS::EKS::Cluster',
+
+  // weakly-typed!
+  properties: {
+    name: 'my-new-cluster',
+    tags: [ { key: 'foo', value: 'bar' } ],
+  },
+});
+```
+
+With `@cdk-cloudformation-extensions` all public resources and modules will be listed in the **Construct Hub** like any
+other construct and by importing the relevant `cdk-cloudformation-extensions` module into their projects, they will be able to
+use them via strongly-typed classes. IDEs will show type information and inline help derived from the
+extension schema.
+
+```ts
+import { Cluster } from '@cdk-cloudformation-extensions/awsqs-eks';
+
+new Cluster(this, 'MyEksCluster', {
+  name: 'my-new-cluster',
+  tags: [ { key: 'foo', value: 'bar' } ],
+});
+```
+
+## Internal FAQ
+
+### Why are we doing this?
+
+We are doing this because CDK users would like to be able to use CloudFormation extensions 
+(modules, resources) as first-class citizens in CDK code. Extensions and native resource types
+should look and feel the same way when defined in CDK apps.
+
+Additionally, we would like to surface CloudFormation extensions in the upcoming Construct Hub
+and to that end, if we simply publish a construct library that includes constructs for all the public,
+extensions, this library will naturally be discoverable through the Hub.
+
+### Why should we _not_ do this?
+
+We have a longer term plan ([RFC#77](https://github.com/aws/aws-cdk-rfcs/issues/77)) to add 
+support for a CLI command called `cdk import` which will allow users to generate L1s from any
+registry type just-in-type and add them to their project (this is similar to CDK8s and CDKtf).
+
+### What is the technical solution (design) of this feature?
+
+The idea is to do something similar to what we do with the CloudFormation L1s 
+in the AWS CDK and simply publish JSII construct libraries which includes 
+statically-generated L1s for all the public registry extensions.
+
+#### Library per type
+
+CloudFormation extensions are semantically versioned. This means that new versions of an extension
+may include breaking changes. We also want to allow users to pick up a specific version of an extension.
+In light of these constraints, we determined that the best path forward is to publish each extension
+as a separate module, with a version that corresponds to the extension version in the CloudFormation
+registry. This way, we will have 1:1 alignment and users will have the most freedom.
+
+#### Code Generator
+
+The code generator will be executed daily (e.g. through a GitHub workflow),
+query the CloudFormation Registry, and generate L1s for all the types based
+on their metadata and schema.
+
+We can use the `ListTypes` API to list all the types in the registry:
+
+```shell
+aws cloudformation list-types --visibility=PUBLIC
+```
+
+And then for each type, we can use `DescribeType` to retrieve the type information and its schema. 
+
+For example, this command will return the description of the `AWSQS::EKS::Cluster` resource:
+
+```shell
+aws cloudformation describe-type --arn arn:aws:cloudformation:us-east-1::type/resource/408988dff9e863704bcc72e7e13f8d645cee8311/AWSQS-EKS-Cluster
+```
+
+For reference: the output of this command can be found [here](https://gist.github.com/eladb/bf417c07444027d6954360295df4ee37#file-awsqs-vpc-vpcqs-module-json). 
+The parsed `Schema` field can be found [here](https://gist.github.com/eladb/bf417c07444027d6954360295df4ee37#file-awsqs-vpc-vpcqs-module-schema-json).
+
+Now, we need to filter all non-`AWS::` types (the `AWS::` types are actually L1s), and then generate 
+an L1 construct for each one. This includes:
+
+1. Generating the construct class that extends `CfnResource`. I think we can use submodules to 
+   represent the type namespace (`awsqs.eks` in this case), and the name of the resource as the construct name `Cluster`.
+2. Generate an `XxxProps` JSII struct for this construct based on the `Schema` field. 
+   This can be done using [`json2jsii`](https://github.com/cdklabs/json2jsii), which is the same 
+   tool we use to implemented the `import` command in CDK8s and CDKtf.
+
+
+### Is this a breaking change?
+
+Nope.
+
+### What are the drawbacks of this solution?
+
+> Describe any problems/risks that can be introduced if we implement this RFC.
+
+### What alternative solutions did you consider?
+
+#### `cdk import` versus library
+
+As mentioned above, an alternative approach would be to add support for `import` in the CDK CLI. The downsides of this approach (at this point) 
+are that (a) it is a bigger investment as it involves a change to the CDK CLI; and (b) the Construct Hub won't be able to surface these
+types automatically (we will need some custom support for "imported" types, which is something that we would like to add to the Construct Hub
+in the future for all CDK domains).
+
+#### Monolithic versus module per resource
+
+As mentioned above, due to the fact that resource schemas are versioned and we want to allow users to select which
+version of the resource they use, we determined that the best approach is to publish a module for each resource.
+This has logicical/operational implications that we believe can mostly be mitigated using projen's capabilities to
+reason about the project structure and publishing workflows using code.
+
+### What is the high level implementation plan?
+
+TBD
+
+### Are there any open issues that need to be addressed later?
+
+* __Property name conversion__: `json2jsii` converts field names to camelCase to adhere with naming typescript naming conventions. 
+  This means that we need to map field names back when we define the `CfnResource`. I think we might want to add a 
+  feature to `json2jsii` that will generate conversion functions that can be used to convert back data types to the original schema.
+
+## Appendix
+
+```ts
+export class Cluster extends CfnResource {
+  constructor(scope: Construct, id: string, props: ClusterProps) {
+    super(scope, id, {
+      type: 'AWSQS::EKS::Cluster',
+      properties: capitalize(props),
+    });
+  }
+}
+
+/**
+ * A resource that creates Amazon Elastic Kubernetes Service (Amazon EKS) clusters.
+ *
+ * @schema ClusterProps
+ */
+export interface ClusterProps {
+  /**
+   * A unique name for your cluster.
+   *
+   * @schema ClusterProps#Name
+   */
+  readonly name?: string;
+
+  /**
+   * Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role. This provides permissions for Amazon EKS to call other AWS APIs.
+   *
+   * @schema ClusterProps#RoleArn
+   */
+  readonly roleArn?: string;
+
+  /**
+   * Name of the AWS Identity and Access Management (IAM) role used for clusters that have the public endpoint disabled. this provides permissions for Lambda to be invoked and attach to the cluster VPC
+   *
+   * @schema ClusterProps#LambdaRoleName
+   */
+  readonly lambdaRoleName?: string;
+
+  /**
+   * Desired Kubernetes version for your cluster. If you don't specify this value, the cluster uses the latest version from Amazon EKS.
+   *
+   * @schema ClusterProps#Version
+   */
+  readonly version?: string;
+
+  /**
+   * Network configuration for Amazon EKS cluster.
+
+
+   *
+   * @schema ClusterProps#KubernetesNetworkConfig
+   */
+  readonly kubernetesNetworkConfig?: ClusterPropsKubernetesNetworkConfig;
+
+  /**
+   * An object that represents the virtual private cloud (VPC) configuration to use for an Amazon EKS cluster.
+   *
+   * @schema ClusterProps#ResourcesVpcConfig
+   */
+  readonly resourcesVpcConfig?: ClusterPropsResourcesVpcConfig;
+
+  /**
+   * Enables exporting of logs from the Kubernetes control plane to Amazon CloudWatch Logs. By default, logs from the cluster control plane are not exported to CloudWatch Logs. The valid log types are api, audit, authenticator, controllerManager, and scheduler.
+   *
+   * @schema ClusterProps#EnabledClusterLoggingTypes
+   */
+  readonly enabledClusterLoggingTypes?: string[];
+
+  /**
+   * Encryption configuration for the cluster.
+   *
+   * @schema ClusterProps#EncryptionConfig
+   */
+  readonly encryptionConfig?: EncryptionConfigEntry[];
+
+  /**
+   * @schema ClusterProps#KubernetesApiAccess
+   */
+  readonly kubernetesApiAccess?: ClusterPropsKubernetesApiAccess;
+
+  /**
+   * ARN of the cluster (e.g., `arn:aws:eks:us-west-2:666666666666:cluster/prod`).
+   *
+   * @schema ClusterProps#Arn
+   */
+  readonly arn?: string;
+
+  /**
+   * Certificate authority data for your cluster.
+   *
+   * @schema ClusterProps#CertificateAuthorityData
+   */
+  readonly certificateAuthorityData?: string;
+
+  /**
+   * Security group that was created by Amazon EKS for your cluster. Managed-node groups use this security group for control-plane-to-data-plane communications.
+   *
+   * @schema ClusterProps#ClusterSecurityGroupId
+   */
+  readonly clusterSecurityGroupId?: string;
+
+  /**
+   * Endpoint for your Kubernetes API server (e.g., https://5E1D0CEXAMPLEA591B746AFC5AB30262.yl4.us-west-2.eks.amazonaws.com).
+   *
+   * @schema ClusterProps#Endpoint
+   */
+  readonly endpoint?: string;
+
+  /**
+   * ARN or alias of the customer master key (CMK).
+   *
+   * @schema ClusterProps#EncryptionConfigKeyArn
+   */
+  readonly encryptionConfigKeyArn?: string;
+
+  /**
+   * Issuer URL for the OpenID Connect identity provider.
+   *
+   * @schema ClusterProps#OIDCIssuerURL
+   */
+  readonly oidcIssuerUrl?: string;
+
+  /**
+   * @schema ClusterProps#Tags
+   */
+  readonly tags?: ClusterPropsTags[];
+
+}
+
+/**
+ * Network configuration for Amazon EKS cluster.
+
+
+ *
+ * @schema ClusterPropsKubernetesNetworkConfig
+ */
+export interface ClusterPropsKubernetesNetworkConfig {
+  /**
+   * Specify the range from which cluster services will receive IPv4 addresses.
+   *
+   * @schema ClusterPropsKubernetesNetworkConfig#ServiceIpv4Cidr
+   */
+  readonly serviceIpv4Cidr?: string;
+
+}
+
+/**
+ * An object that represents the virtual private cloud (VPC) configuration to use for an Amazon EKS cluster.
+ *
+ * @schema ClusterPropsResourcesVpcConfig
+ */
+export interface ClusterPropsResourcesVpcConfig {
+  /**
+   * Specify one or more security groups for the cross-account elastic network interfaces that Amazon EKS creates to use to allow communication between your worker nodes and the Kubernetes control plane. If you don't specify a security group, the default security group for your VPC is used.
+   *
+   * @schema ClusterPropsResourcesVpcConfig#SecurityGroupIds
+   */
+  readonly securityGroupIds?: string[];
+
+  /**
+   * Specify subnets for your Amazon EKS worker nodes. Amazon EKS creates cross-account elastic network interfaces in these subnets to allow communication between your worker nodes and the Kubernetes control plane.
+   *
+   * @schema ClusterPropsResourcesVpcConfig#SubnetIds
+   */
+  readonly subnetIds?: string[];
+
+  /**
+   * Set this value to false to disable public access to your cluster's Kubernetes API server endpoint. If you disable public access, your cluster's Kubernetes API server can only receive requests from within the cluster VPC. The default value for this parameter is true , which enables public access for your Kubernetes API server.
+   *
+   * @schema ClusterPropsResourcesVpcConfig#EndpointPublicAccess
+   */
+  readonly endpointPublicAccess?: boolean;
+
+  /**
+   * Set this value to true to enable private access for your cluster's Kubernetes API server endpoint. If you enable private access, Kubernetes API requests from within your cluster's VPC use the private VPC endpoint. The default value for this parameter is false , which disables private access for your Kubernetes API server. If you disable private access and you have worker nodes or AWS Fargate pods in the cluster, then ensure that publicAccessCidrs includes the necessary CIDR blocks for communication with the worker nodes or Fargate pods.
+   *
+   * @schema ClusterPropsResourcesVpcConfig#EndpointPrivateAccess
+   */
+  readonly endpointPrivateAccess?: boolean;
+
+  /**
+   * The CIDR blocks that are allowed access to your cluster's public Kubernetes API server endpoint. Communication to the endpoint from addresses outside of the CIDR blocks that you specify is denied. The default value is 0.0.0.0/0 . If you've disabled private endpoint access and you have worker nodes or AWS Fargate pods in the cluster, then ensure that you specify the necessary CIDR blocks.
+   *
+   * @schema ClusterPropsResourcesVpcConfig#PublicAccessCidrs
+   */
+  readonly publicAccessCidrs?: string[];
+
+}
+
+/**
+ * The encryption configuration for the cluster.
+ *
+ * @schema EncryptionConfigEntry
+ */
+export interface EncryptionConfigEntry {
+  /**
+   * Specifies the resources to be encrypted. The only supported value is "secrets".
+   *
+   * @schema EncryptionConfigEntry#Resources
+   */
+  readonly resources?: string[];
+
+  /**
+   * @schema EncryptionConfigEntry#Provider
+   */
+  readonly provider?: Provider;
+
+}
+
+/**
+ * @schema ClusterPropsKubernetesApiAccess
+ */
+export interface ClusterPropsKubernetesApiAccess {
+  /**
+   * @schema ClusterPropsKubernetesApiAccess#Roles
+   */
+  readonly roles?: KubernetesApiAccessEntry[];
+
+  /**
+   * @schema ClusterPropsKubernetesApiAccess#Users
+   */
+  readonly users?: KubernetesApiAccessEntry[];
+
+}
+
+/**
+ * @schema ClusterPropsTags
+ */
+export interface ClusterPropsTags {
+  /**
+   * @schema ClusterPropsTags#Value
+   */
+  readonly value?: string;
+
+  /**
+   * @schema ClusterPropsTags#Key
+   */
+  readonly key?: string;
+
+}
+
+/**
+ * AWS Key Management Service (AWS KMS) customer master key (CMK). Either the ARN or the alias can be used.
+ *
+ * @schema Provider
+ */
+export interface Provider {
+  /**
+   * Amazon Resource Name (ARN) or alias of the customer master key (CMK). The CMK must be symmetric, created in the same region as the cluster, and if the CMK was created in a different account, the user must have access to the CMK.
+   *
+   * @schema Provider#KeyArn
+   */
+  readonly keyArn?: string;
+
+}
+
+/**
+ * @schema KubernetesApiAccessEntry
+ */
+export interface KubernetesApiAccessEntry {
+  /**
+   * @schema KubernetesApiAccessEntry#Arn
+   */
+  readonly arn?: string;
+
+  /**
+   * @schema KubernetesApiAccessEntry#Username
+   */
+  readonly username?: string;
+
+  /**
+   * @schema KubernetesApiAccessEntry#Groups
+   */
+  readonly groups?: string[];
+
+}
+```
+```

--- a/text/353-cfn-registry-constructs.md
+++ b/text/353-cfn-registry-constructs.md
@@ -1,4 +1,4 @@
-# {RFC_TITLE}
+# Constructs for Public CloudFormation Extensions
 
 * **Original Author(s):**: @eladb
 * **Tracking Issue**: #353

--- a/text/353-cfn-registry-constructs.md
+++ b/text/353-cfn-registry-constructs.md
@@ -9,14 +9,14 @@ resources and modules published to the public CloudFormation Registry.
 
 ## README
 
-The `@cdk-cloudformation-types/xxx` scope includes construct libraries with generated strongly-typed "L1" constructs
+The `@cdk-cloudformation/xxx` scope includes construct libraries with generated strongly-typed "L1" constructs
 for all the public extensions (resources and modules) in the AWS CloudFormation public registry. This library
 makes it easier to use public CloudFormation extensions in your CDK apps.
 
 For example, let's say I want to define a GitHub repository using the `TF::GitHub::Repository` resource:
 
 ```ts
-import { CfnRepository } from '@cdk-cloudformation-types/tf-github-repository';
+import { CfnRepository } from '@cdk-cloudformation/tf-github-repository';
 
 new CfnRepository(this, 'MyRepo', {
   name: 'my-repo',
@@ -27,7 +27,7 @@ new CfnRepository(this, 'MyRepo', {
 
 For each type (e.g. `TF::GitHub::Repository` in the above example) in
 the public CloudFormation Registry, a module is available under
-the scope `@cdk-cloudformation-types/<namespace-type>`. This library
+the scope `@cdk-cloudformation/<namespace-type>`. This library
 includes a construct class and all the relevant data types for this
 type.
 
@@ -70,13 +70,13 @@ new CfnResource(this, 'MyEksCluster', {
 });
 ```
 
-With `@cdk-cloudformation-types` all public resources and modules will be listed in the **Construct Hub** like any
+With `@cdk-cloudformation` all public resources and modules will be listed in the **Construct Hub** like any
 other construct and by importing the relevant `cdk-cloudformation-extensions` module into their projects, they will be able to
 use them via strongly-typed classes. IDEs will show type information and inline help derived from the
 extension schema.
 
 ```ts
-import { CfnCluster } from '@cdk-cloudformation-types/awsqs-eks-cluster';
+import { CfnCluster } from '@cdk-cloudformation/awsqs-eks-cluster';
 
 new CfnCluster(this, 'MyEksCluster', {
   name: 'my-new-cluster',
@@ -123,29 +123,25 @@ limits), we can shard the solution (multiple accounts, multiple scopes, etc).
 
 #### Naming Scheme
 
-> *This is still not finalized. From a CDK user standpoint, I am not sure if they should really
-> care if these are CloudFormation registry extensions or just normal CDK libraries. Consider a user
-> that goes to Construct Hub and searches for "mongodb". They find this library, import it and use it.
-> As far as they are concerned, they just used a construct library. The fact that this is an L1 type
-> and not some L2/L3 is an implementation details, isn't it. So I am not sure that the semantics which
-> involves "CloudFormation" or "extensions" or "types" is not a leak in the abstraction*.
-
-We will use the following naming scheme:
+We will use the following naming scheme. Names are all derived from the base name of `cdk-cloudformation` which represents the fact
+that these modules include L1s which we also refer to as "CFN resources" in the CDK. Since these are also modules, we decided against
+`cdk-cloudformation-resources`. We also decided not to use the short name `cfn` in the scope. See below for some alternatives considered.
 
 * **npm**: 
-  * Package name: `@cdk-cloudformation-types/<name-kebab-case>` (e.g. `cdk-cloudformation-types/mongodb-atlas-project`)
+  * Package name: `@cdk-cloudformation/<name-kebab-case>` (e.g. `cdk-cloudformation/mongodb-atlas-project`)
 * **Maven Central**:
-  * Group ID: `io.github.cdklabs.cdk_cloudformation_types`
+  * Group ID: `io.github.cdklabs.cdk_cloudformation`
   * Artifact ID: `<name-kebab-case>` (e.g. `mongodb-atlas-project`)
-  * Java Package: `io.github.cdklabs.cdk_cloudformation_types.<name_snake_case>` (e.g. `io.github.cdklabs.cdk_cloudformation.mongodb_atlas_project`)
+  * Java Package: `io.github.cdklabs.cdk_cloudformation.<name_snake_case>` (e.g. `io.github.cdklabs.cdk_cloudformation.mongodb_atlas_project`)
 * **PyPI**:
-  * Distribution name: `cdk-cloudformation-types-<name-kebab-case>` (e.g. `cdk-cloudformation-types-mongodb-atlas-project`)
-  * Module: `cdk_cloudformation_types_<name_snake_case>` (e.g. `cdk_cloudformation_types_mongodb_atlas_project`)
+  * Distribution name: `cdk-cloudformation-<name-kebab-case>` (e.g. `cdk-cloudformation-mongodb-atlas-project`)
+  * Module: `cdk_cloudformation_<name_snake_case>` (e.g. `cdk_cloudformation_mongodb_atlas_project`)
 * **NuGet**:
-  * Package ID: `Cdklabs.CdkCloudFormationTypes.<NamePascalCase>` (e.g. `Cdklabs.CdkCloudFormationTypes.MongodbAtlasProject`)
-  * .NET Namespace: `Cdklabs.CdkCloudFormationTypes.<NamePascalCase>` (e.g. `Cdklabs.CdkCloudFormationTypes.MongodbAtlasProject`)
+  * Package ID: `Cdklabs.CdkCloudFormation.<NamePascalCase>` (e.g. `Cdklabs.CdkCloudFormation.MongodbAtlasProject`)
+  * .NET Namespace: `Cdklabs.CdkCloudFormation.<NamePascalCase>` (e.g. `Cdklabs.CdkCloudFormation.MongodbAtlasProject`)
 
-Alternatives:
+Alternatives considered:
+1. `@cdk-cloudformation-types/mongodb-atlas-project`
 1. `@cdk-types/mongodb-atlas-project`
 2. `@cdk-cfn/mongodb-atlas-project`
 3. `@cdkcfn/mongodb-atlas-project`


### PR DESCRIPTION
This is a proposal to publish construct libraries automatically generated for all public CloudFormation public extensions (resources/modules). See #353 for additional details.

Implementation is under: https://github.com/cdklabs/cdk-cloudformation-types

APIs are signed off by @rix0rrr 

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_

