### PR TITLE
RFC 31: Integration testing for CDK apps

### DIFF
--- a/text/0031-integ-testing.md
+++ b/text/0031-integ-testing.md
@@ -21,11 +21,13 @@ tests that can be run locally or in their CI/CD pipeline.
 
 📸 Capture snapshots of your CDK apps to track how they are impacted by changes.
 
-#### Getting Started
+### Getting Started
 
 > TBD: Installation instructions
 
-#### Writing Tests
+### Writing Tests
+
+contest tests can be written in the same programming language as your CDK project.
 
 Let's start with the below CDK construct that creates an artifact repository in an S3 bucket,
 and notifies of new artifacts to an SQS queue.
@@ -72,7 +74,7 @@ repoTest.assertAws.
      .returns({ Messages: [ ... ] });
 ```
 
-#### Assertions
+### Assertions
 
 `contest` comes packaged with a set of commonly used high level assertions.
 
@@ -96,29 +98,53 @@ The `invokeLambda` API is a special and powerful option.
 Besides invoking lambda functions defined in the CDK construct under test, it can be used to invoke
 lambda functions defined in your test. This mechanism enables user defined assertions as Lambda functions.
 
-> TODO: Explain later that assertions are modeled as CFN custom resources.
+**Implementation Note:** All canned and custom contest assertions are modeled as AWS CloudFormation custom resources.
+They are executed in the AWS account as part of deployment, after the stack or construct under test has been deployed.
 
-#### Test Execution & Reporting
+### Test Execution & Report
 
-contest tests can be written in the same programming language as your CDK project.
+To execute your contest suite, you need to simply run `cdk contest` using the standard AWS CDK CLI.
 
-Execute contest test can be executed by running the `contest` CLI. Each contest test case will be in its
-own file.
-By default, the CLI will look for files named `*.contest.*` and execute them.
-See [configuration](#configuration) *[TODO]* on how to change this.
+For projects that were created prior to the introduction of contest, or were not created using `cdk init`,
+a section for `contest` will need to be added to the `cdk.json` file of your project.
+The following applies to a CDK project in javascript that uses Node.js -
 
-Once all the tests are executed, a test report is printed to the console detailing any deployment and
-assertion failures.
+```json
+{
+  "contest": {
+    "exec": "node {}",
+    "testRegex": "**/*.contest.js"
+  }
+}
+```
+
+- The `testRegex` is the glob pattern to find contest test files.
+- The `exec` key specifies the binary that should be invoked to synthesize a contest test.
+  The `{}` placeholder is required. This will be replaced by each file resolved by the `testRegex` glob.
+
+`cdk contest` will begin by discovering files and executing them one by one.
+As each test is completed, a one line summary of its pass/fail is printed to console.
+Detailed test results are available in a file, usually at `contest.out/results-xxx`.
 
 <!--
 
 #### TBD
 
 - Reporting
+- In the pipeline
 - Revisit custom assertions
 - Snapshots
 - construct library / app upgrades.
 - Run nightly/regularly.
+
+-->
+
+## Working Backwards - README.md
+
+### AWS CDK Toolkit
+
+> TBD
+> For now see, [Test Execution](#test-execution--report) above.
 
 ---
 
@@ -153,7 +179,7 @@ RFC pull request):
 
 > The goal of this section is to help decide if this RFC should be implemented.
 > It should include answers to questions that the team is likely ask. Contrary
-> to the rest of the RFC, answers should be written "from the present" and
+> to the rest of the RFC, answers should be written "in the present" and
 > likely discuss design approach, implementation plans, alternative considered
 > and other considerations that will help decide if this RFC should be
 > implemented.
@@ -187,8 +213,7 @@ RFC pull request):
 
 ### What alternative solutions did you consider?
 
-> Briefly describe alternative approaches that you considered. If there are
-> hairy details, include them in an appendix.
+See [Appendix A](#appendix-a---test-execution) for alternatives on test execution.
 
 ### What are the drawbacks of this solution?
 
@@ -209,10 +234,41 @@ RFC pull request):
 > the RFC is approved, create GitHub issues for these issues and update this RFC
 > of the project board with these issue IDs.
 
-## Appendix
+## Appendix A - Test Execution
 
-Feel free to add any number of appendices as you see fit. Appendices are
-expected to allow readers to dive deeper to certain sections if they like. For
-example, you can include an appendix which describes the detailed design of an
-algorithm and reference it from the FAQ.
--->
+### Implementation
+
+A project set up for contest will have the `contest` section in its `cdk.json`.
+In the case of a javascript CDK app:
+
+```json
+{
+  "contest": {
+    "exec": "node {}",
+    "testRegex": "**/*.contest.js"
+  }
+}
+```
+
+The contest suite for a project is executed by running `cdk contest`.
+
+When invoked, it will discover all contest test cases using the `testRegex` provided and,
+for each match will run synthesis using the `exec` command.
+
+All synthesized CDK apps will be placed under `contest.out/`.
+
+Following this, by default, the CLI will continue and deploy each test. As usual, it will
+poll CloudFormation for its status and print a pass/fail against each test case.
+When a test completes, it will then destroy the stack, before proceeding to run the next test.
+
+At the end of the run, the CLI will download the detailed test results from AWS Logs to the
+location `contest.out/results-xxx`.
+
+### Alternatives
+
+Instead of adding a new CLI subcommand and updated init templates, we could look to reuse
+existing testing frameworks, such as, jest for Node.js, junit for Java, etc.
+This would imply a simpler and a more familiar experience of writing tests.
+
+However, to achieve this effectively, the test cases will need to deploy the app it defines.
+We do not have a way to deploy CDK applications programmatically.

--- a/text/0031-integ-testing.md
+++ b/text/0031-integ-testing.md
@@ -15,7 +15,7 @@ tests that can be run locally or in their CI/CD pipeline.
 
 🤖 apptest can verify that your CDK app functions as expected, such as assertions against a public API endpoint.
 
-💨 apptest can be used to run smoke test against your production stack, and trigger a rollback when they fail.
+💨 run smoke test against your production stack, and trigger a rollback when they fail.
 
 🧑‍💻 Write tests in any CDK supported language, and execute them as part of your CI pipeline.
 
@@ -202,6 +202,31 @@ library when it is used with various valid configurations.
 Each `apptest` case would define a new AWS CDK `Stack` or `App` that includes the construct
 library, followed by assertions. Upon execution, both the app and the assertions will be deployed
 (and finally destroyed) as part of the test execution.
+
+### Smoke tests
+
+Smoke testing is a set of tests that are run after production deployment to reveal failures
+severe enough to rollback the deployment. Besides running tests against pre-production instances,
+apptest can be used to also write smoke test during deployments.
+
+This can be achieved by simply using apptest's assertions as part of the deployment stack.
+
+To invoke an Amazon API Gateway endpoint as part of your smoke test, simply configure -
+
+```ts
+class MyStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    // ...
+    const restApi = new apigateway.RestApi(this, 'MyRestApi');
+    // ...
+    new HttpInvoke(this, 'SmokeTest', {
+      endpoint: `${restApi.url}/ping`,
+    })
+  }
+}
+```
+
+When the smoke test fails, the CloudFormation stack deployment will fail which triggers a rollback.
 
 ## Working Backwards - README.md
 

--- a/text/0031-integ-testing.md
+++ b/text/0031-integ-testing.md
@@ -1,0 +1,201 @@
+# Integration testing for CDK apps
+
+* **Original Author(s):**: [@nija-at](https://github.com/nija-at)
+* **Tracking Issue**: [#31](https://github.com/aws/aws-cdk-rfcs/issues/31)
+* **API Bar Raiser**: @{BAR_RAISER_USER}
+
+CDK app developers and construct library authors can write integration
+tests that can be run locally or in their CI/CD pipeline.
+
+## Working Backwards - README.md
+
+### CDK Integration Testing
+
+🧑‍💻 Write integration tests for your CDK apps and execute them on AWS as part of your CI pipeline.
+
+📸 Capture snapshots of your CDK apps to track how they are impacted by changes.
+
+#### Getting Started
+
+> Installation instructions: TBD
+
+#### Writing Tests
+
+Let's start with a hypothetical CDK stack that defines an AWS Lambda Function which
+records each invoke into an S3 object in a defined bucket.
+
+```ts
+// repo.ts
+import { Construct } from 'constructs';
+import { Bucket, EventType, IBucket } from '@aws-cdk/aws-s3';
+import { IQueue, Queue } from '@aws-cdk/aws-sqs';
+import { SqsDestination } from '@aws-cdk/aws-s3-notifications';
+
+// Set up a private artifact repository
+export class ArtifactRepo extends Construct {
+  public readonly artifacts: IBucket;
+  public readonly publishNotifs: IQueue;
+  
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    this.artifacts = new Bucket(this, 'Artifacts');
+    this.publishNotifs = new Queue(this, 'PublishNotifs');
+
+    this.artifacts.addEventNotification(EventType.OBJECT_CREATED_PUT,
+      new SqsDestination(this.publishNotifs))
+  }
+}
+```
+
+The following test invokes the lambda function and asserts that the expected
+object with contents exists.
+
+```ts
+import { ArtifactRepo } from './records';
+
+const repo = new ArtifactRepo(app, 'RequestRecord');
+
+const repoTest = IntegrationTest.forConstruct(repo); // TBF: Module and class name
+
+repoTest.assertAws.
+  s3.putObject({ bucket: stack.artifacts, key: '...', body: '...' });
+
+repoTest.assertAws.
+  sqs.receiveMessage({ queue: stack.publishNotifs })
+     .returns({ Messages: [ ... ] });
+```
+
+#### Assertions
+
+This module comes packaged with a set of high level assertions that are commonly used
+when writing tests with the AWS CDK.
+
+* `assertAws`: execute AWS service APIs and assert the response.
+* `invokeLambda`: invoke an AWS lambda function and assert the response.
+* `curlApi`: Execute the 'curl' command on an API endpoint. Used typically to test API Gateway resources.
+
+By default, these assertions will check that the underlying call succeeds. That behavior can be modified
+to verify the response or to verify error.
+
+```ts
+test.assertAws(
+  s3.getObject({ ... }).returns({ Data: ... });
+);
+
+test.invokeLambda(...).returns({ ... });
+test.invokeLambda(...).throws({ ... });
+```
+
+The `invokeLambda` API is a special and powerful option.
+Besides invoking lambda functions defined in your application, it can be used to
+run custom actions and assertions in the test.
+
+For example, with `ArtifactRepo`, the test may include a lambda function that verifies
+by installing an artifact from this repository.
+
+> TODO: Explain that assertions are constructs / custom resources.
+
+#### TBD
+
+- Running tests
+- Snapshots
+- construct library / app upgrades.
+- Run nightly/regularly.
+
+---
+
+Ticking the box below indicates that the public API of this RFC has been
+signed-off by the API bar raiser (the `api-approved` label was applied to the
+RFC pull request):
+
+```
+[ ] Signed-off by API Bar Raiser @xxxxx
+```
+
+## Public FAQ
+
+> This section should include answers to questions readers will likely ask about
+> this release. Similar to the "working backwards", this section should be
+> written in a language as if the feature is now released.
+>
+> The template includes a some common questions, feel free to add any questions
+> that might be relevant to this feature or omit questions that you feel are not
+> applicable.
+
+### What are we launching today?
+
+> What exactly are we launching? Is this a new feature in an existing module? A
+> new module? A whole framework? A change in the CLI?
+
+### Why should I use this feature?
+
+> Describe use cases that are addressed by this feature.
+
+## Internal FAQ
+
+> The goal of this section is to help decide if this RFC should be implemented.
+> It should include answers to questions that the team is likely ask. Contrary
+> to the rest of the RFC, answers should be written "from the present" and
+> likely discuss design approach, implementation plans, alternative considered
+> and other considerations that will help decide if this RFC should be
+> implemented.
+
+### Why are we doing this?
+
+> What is the motivation for this change?
+
+### Why should we _not_ do this?
+
+> Is there a way to address this use case with the current product? What are the
+> downsides of implementing this feature?
+
+### What is the technical solution (design) of this feature?
+
+> Briefly describe the high-level design approach for implementing this feature.
+>
+> As appropriate, you can add an appendix with a more detailed design document.
+>
+> This is a good place to reference a prototype or proof of concept, which is
+> highly recommended for most RFCs.
+
+### Is this a breaking change?
+
+> If the answer is no. Otherwise:
+>
+> Describe what ways did you consider to deliver this without breaking users?
+>
+> Make sure to include a `BREAKING CHANGE` clause under the CHANGELOG section with a description of the breaking
+> changes and the migration path.
+
+### What alternative solutions did you consider?
+
+> Briefly describe alternative approaches that you considered. If there are
+> hairy details, include them in an appendix.
+
+### What are the drawbacks of this solution?
+
+> Describe any problems/risks that can be introduced if we implement this RFC.
+
+### What is the high-level project plan?
+
+> Describe your plan on how to deliver this feature from prototyping to GA.
+> Especially think about how to "bake" it in the open and get constant feedback
+> from users before you stabilize the APIs.
+>
+> If you have a project board with your implementation plan, this is a good
+> place to link to it.
+
+### Are there any open issues that need to be addressed later?
+
+> Describe any major open issues that this RFC did not take into account. Once
+> the RFC is approved, create GitHub issues for these issues and update this RFC
+> of the project board with these issue IDs.
+
+## Appendix
+
+Feel free to add any number of appendices as you see fit. Appendices are
+expected to allow readers to dive deeper to certain sections if they like. For
+example, you can include an appendix which describes the detailed design of an
+algorithm and reference it from the FAQ.
+-->

--- a/text/0031-integ-testing.md
+++ b/text/0031-integ-testing.md
@@ -9,21 +9,21 @@ tests that can be run locally or in their CI/CD pipeline.
 
 ## Working Backwards - README.md
 
-### contest *[name not final]*
+### `@aws-cdk/app-test`
 
-🌩️ contest tests can verify that your CDK app can be deployed successfully on AWS with the desired resources.
+🌩️ app-test can verify that your CDK app can be deployed successfully on AWS with the desired resources.
 
-🤖 contest tests can verify that your CDK app functions as expected, such as assertions against a public API endpoint.
+🤖 app-test can verify that your CDK app functions as expected, such as assertions against a public API endpoint.
 
-🧑‍💻 Write contest tests in any CDK supported language, and execute them as part of your CI pipeline.
+🧑‍💻 Write tests in any CDK supported language, and execute them as part of your CI pipeline.
 
 📸 Capture snapshots of your CDK apps to track how they are impacted by changes.
 
-🧹 contest will clean up any AWS resources that it had to provision, and keep your AWS costs to the minimum.
+🧹 app-test will clean up any AWS resources that it had to provision, and keep your AWS costs to the minimum.
 
 ### Writing Tests
 
-contest tests can be written in the same programming language as your CDK project.
+Tests that use app-test can be written in the same programming language as your CDK project.
 
 Let's start with the below CDK construct that creates an artifact repository in an S3 bucket,
 and notifies of new artifacts to an SQS queue.
@@ -54,9 +54,9 @@ export class ArtifactRepo extends Construct {
 The following integ test invokes puts an object in the S3 bucket and verifies the message in the SQS queue.
 
 ```ts
-// repo.contest.ts
+// repo.apptest.ts
 import { ArtifactRepo } from './records';
-import { AwsAssertionCall, AwsAssertion, Test } from '@aws-cdk/contest';
+import { AwsAssertionCall, AwsAssertion, Test } from '@aws-cdk/app-test';
 
 const repo = new ArtifactRepo(app, 'RequestRecord');
 
@@ -74,7 +74,7 @@ new AwsAssertion(repoTest, 'MessageReceived', {
 
 ### Assertions
 
-`contest` comes canned with a set of commonly used high level assertions.
+`app-test` comes canned with a set of commonly used high level assertions.
 
 * `AwsAssertion`: execute AWS service APIs and assert the response.
 * `InvokeLambda`: invoke an AWS Lambda Function and assert its response.
@@ -96,7 +96,7 @@ new InvokeLambda(test, 'Invoke', {
 });
 ```
 
-When canned assertions are insufficient, `contest` also provides a mechanism to write custom assertions.
+When canned assertions are insufficient, `app-test` also provides a mechanism to write custom assertions.
 Custom assertions are simply AWS Lambda Functions, and in the CDK, these are any construct that implements `IFunction`.
 
 ```ts
@@ -129,46 +129,46 @@ test.invokeLambda(hdrAssertion);
 
 ### Test Execution & Report
 
-To execute your contest suite, you need to simply run `cdk contest` using the standard AWS CDK CLI.
+To execute your app-test suite, you need to simply run `cdk app-test` using the standard AWS CDK CLI.
 
-For projects that were created prior to the introduction of contest, or were not created using `cdk init`,
-a section for `contest` will need to be added to the `cdk.json` file of your project.
+For projects that were created prior to the introduction of app-test, or were not created using `cdk init`,
+a section for `app-test` will need to be added to the `cdk.json` file of your project.
 The following applies to a CDK project in javascript that uses Node.js -
 
 ```json
 {
-  "contest": {
+  "app-test": {
     "exec": "node {}",
-    "testRegex": "**/*.contest.js"
+    "testRegex": "**/*.apptest.js"
   }
 }
 ```
 
-- The `testRegex` is the glob pattern to find contest test files.
-- The `exec` key specifies the binary that should be invoked to synthesize a contest test.
+- The `testRegex` is the glob pattern to find app-test test files.
+- The `exec` key specifies the binary that should be invoked to synthesize a app-test test.
   The `{}` placeholder is required. This will be replaced by each file resolved by the `testRegex` glob.
 
-`cdk contest` will begin by discovering files and executing them one by one.
+`cdk app-test` will begin by discovering files and executing them one by one.
 As each test is completed, a one line summary of its pass/fail is printed to console.
-Detailed test results are available in a file, usually at `contest.out/results-xxx`.
+Detailed test results are available in a file, usually at `app-test.out/results-xxx`.
 
 ### Test snapshots
 
-On first run of a contest test, a snapshot will be produced that *must be checked into source tree*.
+On first run of a app-test test, a snapshot will be produced that *must be checked into source tree*.
 This is a snapshot of the [cloud assembly] containing both the CDK app (being tested) and the test's
 assertions. The snapshot will be placed at a folder relative to the test file.
 
 ```
 test
-├── repo.contest.ts
-└── repo.contest.snap
+├── repo.apptest.ts
+└── repo.apptest.snap
     ├── manifest.json
     ├── RepoStack.template.json
     ├── ...
     └── ...
 ```
 
-On subsequent runs of this test - via `cdk contest` - if the synthesized cloud assembly matches the
+On subsequent runs of this test - via `cdk app-test` - if the synthesized cloud assembly matches the
 snapshot, then a full deployment and assertions will be skipped and the test will be considered to
 have passed. This behaviour can be overridden with the `--ignore-snapshots` flag.
 
@@ -222,7 +222,7 @@ RFC pull request):
 
 > Describe use cases that are addressed by this feature.
 
-### Why are all my contest snapshots sometimes invalidated when I upgrade to a newer CDK version?
+### Why are all my app-test snapshots sometimes invalidated when I upgrade to a newer CDK version?
 
 This usually happens when your CDK app depends on an asset that is bundled as part of the AWS CDK.
 Learn more about [assets].
@@ -230,7 +230,7 @@ Learn more about [assets].
 Assets bundled as part of the CDK can change when there is a bug fix or a new feature added to the
 asset. When an asset changes, its fingerprint (hash) stored in the CloudFormation template also changes.
 
-With such changes, it is best to re-run all your tests in full (as is the default by `cdk contest`)
+With such changes, it is best to re-run all your tests in full (as is the default by `cdk app-test`)
 to ensure that all of the new changes do not have any unintended impact to your application.
 
 Rarely, the AWS CDK will change the synthesized template in backwards compatible ways, such as,
@@ -284,46 +284,46 @@ See [Appendix B](#appendix-b---assertions) for alternatives on assertions design
 
 ### Are there any open issues that need to be addressed later?
 
-The RFC does not describe the experience of using contest in CDK Pipelines.
+The RFC does not describe the experience of using app-test in CDK Pipelines.
 This needs to be incorporated later.
 
 ## Appendix A - Test Execution
 
 ### Design
 
-A project set up for contest will have the `contest` section in its `cdk.json`.
+A project set up for app-test will have the `app-test` section in its `cdk.json`.
 In the case of a javascript CDK app:
 
 ```json
 {
-  "contest": {
+  "app-test": {
     "exec": "node {}",
-    "testRegex": "**/*.contest.js"
+    "testRegex": "**/*.apptest.js"
   }
 }
 ```
 
-The contest suite for a project is executed by running `cdk contest`.
+The app-test suite for a project is executed by running `cdk app-test`.
 
-When invoked, it will discover all contest test cases using the `testRegex` provided and,
+When invoked, it will discover all app-test test cases using the `testRegex` provided and,
 for each match will run synthesis using the `exec` command.
 
-All synthesized CDK apps will be placed under `contest.out/`.
+All synthesized CDK apps will be placed under `apptest.out/`.
 
 Following this, by default, the CLI will continue and deploy each test. As usual, it will
 poll CloudFormation for its status and print a pass/fail against each test case.
 When a test completes, it will then destroy the stack, before proceeding to run the next test.
 
 At the end of the run, the CLI will download the detailed test results from AWS Logs to the
-location `contest.out/results-xxx`.
+location `apptest.out/results-xxx`.
 
 The major downside to this solution is that it is re-inventing another test execution mechanism.
 
-Users will now need to learn how to organize contest tests, learn how to execute it and read
+Users will now need to learn how to organize app-test tests, learn how to execute it and read
 results. We are not leveraging existing "well known" test frameworks.
 
-Although this looks basic today, as the scope of contest expands and more features are added,
-the contest test execution mechanism will likely have to re-implement features that are
+Although this looks basic today, as the scope of app-test expands and more features are added,
+the app-test test execution mechanism will likely have to re-implement features that are
 already present in most popular testing frameworks today.
 
 The proposal does not produce the test report in any known format, and this is going to lead
@@ -343,10 +343,10 @@ applications. Currently, this is available only via the AWS CDK CLI.
 
 ## Appendix B - Assertions
 
-All contest assertions are AWS Lambda functions at their core and uses AWS CloudFormation
+All app-test assertions are AWS Lambda functions at their core and uses AWS CloudFormation
 [custom resources] to execute these during deployment.
 
-contest ships with a single custom resource provider and every call to an assertion
+app-test ships with a single custom resource provider and every call to an assertion
 provisions a new CloudFormation custom resource using this provider. Every assertion is a
 lambda function.
 

--- a/text/0031-integ-testing.md
+++ b/text/0031-integ-testing.md
@@ -11,13 +11,13 @@ tests that can be run locally or in their CI/CD pipeline.
 
 ### contest
 
-🌩️ `contest` tests can verify that your CDK app can be deployed successfully on AWS with the desired resources.
+🌩️ contest tests can verify that your CDK app can be deployed successfully on AWS with the desired resources.
 
-🤖 `contest` tests can verify that your CDK app functions as expected, such as assertions against a public API endpoint.
+🤖 contest tests can verify that your CDK app functions as expected, such as assertions against a public API endpoint.
 
-🕰️ `contest` tests can verify that your CDK app can be updated from a previous version of the app.
+🕰️ contest tests can verify that your CDK app can be updated from a previous version of the app.
 
-🧑‍💻 Write `contest` tests in any CDK supported language, and execute them as part of your CI pipeline.
+🧑‍💻 Write contest tests in any CDK supported language, and execute them as part of your CI pipeline.
 
 📸 Capture snapshots of your CDK apps to track how they are impacted by changes.
 
@@ -98,16 +98,17 @@ lambda functions defined in your test. This mechanism enables user defined asser
 
 > TODO: Explain later that assertions are modeled as CFN custom resources.
 
-#### Test Execution
+#### Test Execution & Reporting
 
-`contest` tests can be written in any of the CDK supported languages.
+contest tests can be written in the same programming language as your CDK project.
 
-NOTE: If your project also contains unit tests, consider separating these from `contest` tests,
-using separate targets (separate `script` in a node project, separate Maven phase in a Java project, etc.).
+Execute contest test can be executed by running the `contest` CLI. Each contest test case will be in its
+own file.
+By default, the CLI will look for files named `*.contest.*` and execute them.
+See [configuration](#configuration) *[TODO]* on how to change this.
 
-Tests are executed within an AWS account; hence its credentials are required during test execution.
-
-> TODO: Expand on credentials requirements
+Once all the tests are executed, a test report is printed to the console detailing any deployment and
+assertion failures.
 
 <!--
 

--- a/text/0031-integ-testing.md
+++ b/text/0031-integ-testing.md
@@ -196,7 +196,52 @@ test runners.
 
 ### `cdk-deploy`
 
-> TBD
+This jsii module provides the ability to programmatically deploy and destroy AWS CDK apps.
+
+A CDK app can be deployed by calling -
+
+```ts
+import { App } from 'cdk-deploy';
+
+const app = new App('/path/to/cdk/app');
+app.deploy();
+...
+app.destroy();
+```
+
+The path provided here can be a path to a project that contains a `cdk.json` file or a path
+to a CDK app [cloud assembly].
+
+The `deploy()` and `destroy()` APIs will block further program execution until the deployment
+or destruction complete. If the action fails, the API will throw an error.
+Asynchronous support for `deploy()` and `destroy()` are not available yet.
+
+> TBD: configurable options of deploy and destroy
+
+By default, the APIs print their output and progress to stdout. This can be configured
+using options on the APIs.
+
+```ts
+app.deploy({
+  stdout: false,
+  outfile: '/path/to/file' // path to file where the progress should be printed
+});
+```
+
+#### Credentials
+
+This module uses the AWS SDK for Javascript under the hood to communicate with CloudFormation.
+We support most of the common ways in which [this SDK allows setting
+credentials](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html).
+
+Credentials are loaded from the following and in the given order of precedence,
+
+1. [Environment variables](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-environment.html)
+1. [Shared credentials file](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-shared.html)
+1. Execution platform credentials provider, such as,
+   [IAM roles for Amazon EC2](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-iam.html),
+   [IAM roles for AWS Lambda](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-lambda.html),
+   or Amazon ECS credentials provider.
 
 ---
 

--- a/text/0031-integ-testing.md
+++ b/text/0031-integ-testing.md
@@ -7,28 +7,6 @@
 CDK app developers and construct library authors can write integration
 tests that can be run locally or in their CI/CD pipeline.
 
-## Requirements
-
-It's useful to begin this RFC by talking about the requirements for CDK app integration testing.
-
-As a CDK app developer, I must be able to,
-
-1. Write tests that specifies (my) CDK app or stack(s) and execute a set of assertions against the deployed stack(s).
-   * Assertions are typically a series of API calls to AWS services,
-     but can be any "script" executed in a well defined environment.
-1. Execute the above tests both locally (given AWS credentials) and as part of my CI/CD pipeline,
-   including CDK Pipelines.
-1. Execute the above tests in "snapshot mode", so as to visually determine the impact of a given change.
-   * In this mode, the stacks and assertions are not actually deployed. Instead, the CDK app is synthesized and the
-     generated cloud assembly is compared against an existing snapshot.
-1. Execute the above tests in "update mode", so as to verify that updating an existing app is successful.
-   * In this mode, a previous (snapshotted) version of the CDK app is first deployed, followed by the new changes.
-1. Write tests in the same language as my CDK app.
-
-Additionally,
-
-1. Tests must clean up all artifacts created in the AWS account during its run at the end of its execution.
-
 ## Working Backwards - README.md
 
 ### contest


### PR DESCRIPTION
This is a request for comments about Integration testing for CDK apps.
See #31  for additional details. 

Readable version: https://github.com/aws/aws-cdk-rfcs/blob/nija-at/integ-tests/text/0031-integ-testing.md

APIs are signed off by @{BAR_RAISER}.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_

