### PR TITLE
chore: add settings for the "cdk watch" command

### DIFF
--- a/text/0001-cdk-update.md
+++ b/text/0001-cdk-update.md
@@ -97,8 +97,8 @@ The "watch" functionality can be customized by setting a few new options in your
       "app": "mvn exec:java",
       "build": "mvn package",
       "watch": {
-        "include": ["src", "lambda/code/**/*"],
-        "exclude": ["cdk.out", "target"]
+        "include": ["./**"],
+        "exclude": ["target"]
       }
     }
     ```
@@ -106,6 +106,8 @@ The "watch" functionality can be customized by setting a few new options in your
     The `cdk init` command fills these out for you,
     so if your project has a standard layout,
     you shouldn't need to modify these from the generated defaults.
+    Also note that the output directory (`cdk.out` by default)
+    is always automatically excluded, so doesn't need to be specified in the `cdk.json` file.
 
 In addition to the monitoring mode, it is possible to perform one-shot
 hotswap deployments on some or all of the stacks in the CDK application:


### PR DESCRIPTION
This PR updates the "CDK Watch" RFC with details of how to customize the watching process by introducing new options to the `cdk.json` file:

* A `"build"` key that allows specifying what command(s) should be executed before the project is synthesized.
* A `"watch"` key with two sub-keys, `"include"` and `"exclude"`, that allows specifying what files should be observed for changes, and which ones should be ignored by the watcher.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_

