### PR TITLE
chore: update CDKv2 RFC guidance for v1 dist tags post-launch

### DIFF
--- a/text/0079-cdk-2.0.md
+++ b/text/0079-cdk-2.0.md
@@ -311,8 +311,8 @@ of CDKv1, i.e., `1.x.y`.
 
 When CDKv2 is declared GA, the `v2` distribution tag will be updated once to
 match the first GA release, and the `latest` distribution tag will start
-tracking the versions of CDKv2. A new distribution tag called `v1` will be
-created to track the latest release of CDK `1.x.y`.
+tracking the versions of CDKv2. A new distribution tag called `latest-1`
+will be created to track the latest release of CDK `1.x.y`.
 
 [semantic versioning]: https://semver.org/#spec-item-9
 [pom version order]:


### PR DESCRIPTION
The RFC currently specifies that post-launch of CDK v2, the v2 packages will get
an NPM distribution tag of `latest`, and the v1 packages will get a tag of
`v1`. However, tags that can be interpreted as valid semver ranges are not
allowed, and it is impossible to publish without a tag. Rename the tag to
`latest-1` to get around this. This is the same convention `npm` uses for its
releases.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_

