### PR TITLE
Add customer pains to the RFC

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -7,6 +7,9 @@
 > Write one sentence which is a brief description of the feature from a user
 > perspective ("impact on users").
 
+## Customer pains
+Describe in short the customer pains your'e trying to solve.
+
 ## Working Backwards
 
 > This section should contain one or more "artifacts from the future", as if the

--- a/0000-template.md
+++ b/0000-template.md
@@ -4,11 +4,9 @@
 * **Tracking Issue**: #{TRACKING_ISSUE}
 * **API Bar Raiser**: @{BAR_RAISER_USER}
 
-> Write one sentence which is a brief description of the feature from a user
-> perspective ("impact on users").
-
-## Customer pains
-Describe in short the customer pains your'e trying to solve.
+> Write one sentence which is a brief description of the feature. It should describe:
+> * What is the user pain we are solving?
+> * How does it impact users?
 
 ## Working Backwards
 


### PR DESCRIPTION
IMHO it will be easier to read through the RFC if we will add a section for Customer Pains at the beginning of the RFC. 
This section should describe the customer pain only, without any implementation details.

This is a request for comments about {RFC_DESCRIPTION}. See #{TRACKING_ISSUE} for
additional details. 

APIs are signed off by @{BAR_RAISER}.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_

