### PR TITLE
feat(RFC-204): propose go generics use in go bindings

### DIFF
--- a/text/204-golang-bindings.md
+++ b/text/204-golang-bindings.md
@@ -1195,7 +1195,7 @@ interfaces with a non-exported implementing struct. A run-time check can be wove
 provide helpful error messages (this can be done regardless of how optionals are implemented, as the type model has the
 required information).
 
-While turning an required parameter to optional is not a usage-breaking change in this scenario, it is as an
+While turning a required parameter to optional is not a usage-breaking change in this scenario, it is as an
 override-breaking change, as the type signature of the function that must be implemented to satisfy an interface
 changes. This has consequences in case a type extends a go interface from a dependency.
 


### PR DESCRIPTION
This proposes making use of `go 1.18+` generics in generated go bindings in order to label optional values as such, and remove the pervasive use of pointers.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_

