### PR TITLE
fix: mergify config uses deprecated "strict" mode

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,15 +1,28 @@
 
 # See https://doc.mergify.io
 
+queue_rules:
+  - name: default
+    conditions:
+      - -title~=(WIP|wip)
+      - -label~=(blocked|do-not-merge)
+      - -merged
+      - -closed
+      - "#approved-reviews-by>=1"
+      - -approved-reviews-by~=author
+      - "#changes-requested-reviews-by=0"
+      - "#commented-reviews-by=0"
 pull_request_rules:
   - name: automatic merge
     actions:
       comment:
         message: Thank you for contributing! Your pull request is now being automatically merged.
-      merge:
-        strict: smart
+      queue:
         method: squash
-        strict_method: merge
+        name: default
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+          {{ body }}
       delete_head_branch: {}
       dismiss_reviews: {}
     conditions:


### PR DESCRIPTION
Example of error message reported by current config: https://github.com/aws/aws-cdk-rfcs/runs/4805415314

I updated the config based on the information in https://blog.mergify.com/strict-mode-deprecation/.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_

