### PR TITLE
chore: upgrade Node versions in GitHub workflows

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 18.x
       - name: run linter
         run: ./lint.sh

--- a/.github/workflows/render-table.yml
+++ b/.github/workflows/render-table.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 18.x
       - name: install dependencies
         run: |
           cd tools/rfc-render


### PR DESCRIPTION
This is necessary to have any modern packages work.

Right now a Dependabot PR is failing with `no such module: 'node:fs'` 🥴.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_

