### PR TITLE
chore(mergify): move deprecated parameters from `pull_request_rules` to `queue_rules`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,17 +12,18 @@ queue_rules:
       - -approved-reviews-by~=author
       - "#changes-requested-reviews-by=0"
       - "#commented-reviews-by=0"
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+      {{ body }}
+
 pull_request_rules:
   - name: automatic merge
     actions:
       comment:
         message: Thank you for contributing! Your pull request is now being automatically merged.
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-          {{ body }}
       delete_head_branch: {}
       dismiss_reviews: {}
     conditions:


### PR DESCRIPTION
We are using deprecated parameters that are about to be removed (October 21st, 2024).

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_

