### PR TITLE
chore(tools): modernize RFC render tools

### DIFF
--- a/.github/workflows/render-table.yml
+++ b/.github/workflows/render-table.yml
@@ -24,9 +24,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: lts/*
       - name: install dependencies
         run: npm --prefix tools/rfc-render ci
       - name: render tables

--- a/tools/rfc-render/fetch-issues.js
+++ b/tools/rfc-render/fetch-issues.js
@@ -1,13 +1,15 @@
-const { Octokit } = require('@octokit/rest');
-const { STATUS_LIST, UNKNOWN_STATUS } = require('./status');
-const fs = require('fs').promises;
-const path = require('path');
+import { Octokit } from "@octokit/rest";
+import { STATUS_LIST, UNKNOWN_STATUS } from './status.js';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-exports.issuesGroupedByStatus = issuesGroupedByStatus;
+export { issuesGroupedByStatus };
 
 const STATUS_LABELS = Object.keys(STATUS_LIST);
 
 async function issuesGroupedByStatus(filterStatus = undefined) {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const files = await fs.readdir(path.join(__dirname, '..', '..', 'text'));
 
   const octo = new Octokit({
@@ -21,6 +23,7 @@ async function issuesGroupedByStatus(filterStatus = undefined) {
   console.log(fullQuery);
   const request = octo.search.issuesAndPullRequests.endpoint.merge({
     q: fullQuery,
+    advanced_search: true,
   });
 
   const result = await octo.paginate(request);

--- a/tools/rfc-render/inject-table.js
+++ b/tools/rfc-render/inject-table.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-const fs = require('fs').promises;
-const path = require('path');
-const { render } = require('./render-rfc-table');
-const { parseArgs } = require('util');
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { render } from './render-rfc-table.js';
+import { parseArgs } from 'util';
 
 async function main() {
   const { values: { status = undefined }, positionals: [readme = 'README.md'] } = parseArgs({
@@ -44,6 +45,7 @@ main().catch(e => {
   console.error();
   console.error(e);
   console.error();
-  console.error(`Usage:\n\t${path.relative(process.cwd(), process.argv[1])} README.md [--status <STATUS_1>] [--status <STATUS_2>] [...]`)
+  const __filename = fileURLToPath(import.meta.url);
+  console.error(`Usage:\n\t${path.relative(process.cwd(), __filename)} README.md [--status <STATUS_1>] [--status <STATUS_2>] [...]`)
   process.exitCode = 1;
 });

--- a/tools/rfc-render/package.json
+++ b/tools/rfc-render/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "render:all": "npm run render:readme && npm run render:full && npm run render:proposed && npm run render:accepted && npm run render:closed",
     "render:readme": "node inject-table.js ../../README.md -s unknown -s implementing -s planning -s approved -s final-comment-period -s api-approved -s review",

--- a/tools/rfc-render/render-rfc-table.js
+++ b/tools/rfc-render/render-rfc-table.js
@@ -1,8 +1,8 @@
-const { issuesGroupedByStatus } = require('./fetch-issues');
-const { STATUS_LIST } = require('./status');
+import { issuesGroupedByStatus } from './fetch-issues.js';
+import { STATUS_LIST } from './status.js';
 
 const labels = Object.keys(STATUS_LIST);
-exports.render = render;
+export { render };
 
 async function render(renderStatus = undefined, groupByStatus = true) {
   const issuesByStatus = await issuesGroupedByStatus(renderStatus);

--- a/tools/rfc-render/status.js
+++ b/tools/rfc-render/status.js
@@ -1,9 +1,9 @@
-exports.UNKNOWN_STATUS = 'status/unknown';
+export const UNKNOWN_STATUS = 'status/unknown';
 
 // Order does not matters here
 // The cli input is an ordered list of status
-exports.STATUS_LIST = {
-  [exports.UNKNOWN_STATUS]: '❓unknown',
+export const STATUS_LIST = {
+  [UNKNOWN_STATUS]: '❓unknown',
   'status/implementing': '👷 implementing',
   'status/planning': '📆 planning',
   'status/approved': '👍 approved',


### PR DESCRIPTION
This PR modernizes the RFC render tools by:

- Converting CommonJS to ES modules
- Updating GitHub Actions to use Node.js LTS
- Adding support for URL imports in Node.js
- Fixing file path resolution with ES modules

This change improves maintainability and keeps the tooling up to date with modern JavaScript practices.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_