### PR TITLE
chore: use the trusted package-lock.json for `npm ci`

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -2,8 +2,8 @@
 # executes markdownlint on all RFCs
 # --fix to fix errors
 set -euo pipefail
-scriptdir=$(cd $(dirname $0) && pwd)
-linters=$PWD/tools/linters
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+linters=$SCRIPT_DIR/tools/linters
 
 (cd $linters && npm ci)
 cliargs="--ignore node_modules --ignore tools ${@:1}"


### PR DESCRIPTION
Using `$PWD` to determine where to find the `package-lock.json` file is insecure. If we run it from GitHub workflow like this:


```yaml
# Run linter from 'main' on the working copy
- name: run linter
  run: |
    cd checkout_pr
    ../checkout_main/lint.sh
```

where `checkout_pr` is the directory where the PR branch was cloned, then `$PWD` will resolve to the PR working directory, not the base repository.

Replace it with the directory where the script itself is located, to guarantee that we are using a trusted `package-lock.json`.


---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_

