### PR TITLE
chore: fix lint errors in RFC 0728 - AWS Elemental MediaPackage V2 L2…

### DIFF
--- a/text/0728-aws-elemental-mediapackagev2-l2.md
+++ b/text/0728-aws-elemental-mediapackagev2-l2.md
@@ -296,6 +296,7 @@ export interface IChannelGroup extends IResource {
 ```
 
 Provide fromMethod capability - allowing imports of the resource:
+
 ```
 /**
   * Creates a Channel Group construct that represents an external (imported) Channel Group.
@@ -507,6 +508,7 @@ export interface IChannel extends IResource {
 ```
 
 Provide fromMethod capability - allowing imports of the resource:
+
 ```
 /**
   * Creates a Channel construct that represents an external (imported) Channel.
@@ -970,6 +972,7 @@ export interface IOriginEndpoint extends IResource {
 ```
 
 Provide fromMethod capability - allowing imports of the resource:
+
 ```
 /**
   * Creates a OriginEndpoint construct that represents an external (imported) OriginEndpoint.


### PR DESCRIPTION
Fixed a few lint errors in this RFC relating to newlines before "```" bodies in the markdown file.

… Construct

This is a request for comments about {RFC_DESCRIPTION}. See #{TRACKING_ISSUE} for
additional details. 

APIs are signed off by @{BAR_RAISER}.

---

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_

