### PR TITLE
chore: fixed lint error in RFC 788

### DIFF
--- a/text/0788-bedrock-agentcore-memory-l2.md
+++ b/text/0788-bedrock-agentcore-memory-l2.md
@@ -296,7 +296,7 @@ const memory = new agentcore.Memory(this, "MyMemory", {
 
 ### Memory with self-managed Strategies
 
-A self-managed strategy in Amazon Bedrock AgentCore Memory gives you complete control over your memory extraction and consolidation pipelines. 
+A self-managed strategy in Amazon Bedrock AgentCore Memory gives you complete control over your memory extraction and consolidation pipelines.
 With a self-managed strategy, you can build custom memory processing workflows while leveraging Amazon Bedrock AgentCore for storage and retrieval.
 
 For additional information, you can refer to the [developer guide for self managed strategies](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/memory-self-managed-strategies.html).


### PR DESCRIPTION
Fixed a lint error in RFC 788 by removing a trailing whitespace on line 299.

_By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache-2.0 license_

