### PR TITLE
chore: Fix markdownlint line-length violations in RFC text files

### DIFF
--- a/text/0300-programmatic-toolkit.md
+++ b/text/0300-programmatic-toolkit.md
@@ -355,7 +355,8 @@ RFC pull request):
 
 ### What are we launching today?
 
-We are launching the [Programmatic Toolkit], a new TypeScript package that enables integrators to build custom lifecycle management solutions for CDK applications.
+We are launching the [Programmatic Toolkit], a new TypeScript package that enables integrators to build custom lifecycle management
+solutions for CDK applications.
 The toolkit provides implementation for all of the CDK's actions like bootstrap, synth or deploy.
 It gives integrators full control over all output and allows to interweave actions with custom steps.
 
@@ -648,7 +649,8 @@ interface RecoverableError<T, U> extends IoRequest<T, U> {
 }
 ```
 
-When `IoHost.requestResponse()` is called with a recoverable error, the integrator may choose to return `retry: true` to indicate the block should be retried.
+When `IoHost.requestResponse()` is called with a recoverable error, the integrator may choose to return `retry: true` to indicate
+the block should be retried.
 A single retry is allowed, if the block fails again with the same error it will be raised as an exception.
 Retries are not guaranteed and integrators must handle the case where a requested retry is not executed.
 Recoverable errors are rare as they require special programming and not always possible.

--- a/text/0474-event-bridge-scheduler-l2.md
+++ b/text/0474-event-bridge-scheduler-l2.md
@@ -48,7 +48,8 @@ See below
 # Amazon EventBridge Scheduler Contruct Library
 
 [Amazon EventBridge Scheduler](https://aws.amazon.com/blogs/compute/introducing-amazon-eventbridge-scheduler/) is a feature from Amazon EventBridge that
-allows you to create, run, and manage scheduled tasks at scale. With EventBridge Scheduler, you can schedule one-time or recurrently tens of millions of
+allows you to create, run, and manage scheduled tasks at scale. With EventBridge Scheduler, you can schedule one-time or recurrently tens of millions
+of
 tasks across many AWS services without provisioning or managing underlying infrastructure.
 
 1. **Schedule**: A schedule is the main resource you create, configure, and manage using Amazon EventBridge Scheduler.

--- a/text/0502_aws-vpclattice.md
+++ b/text/0502_aws-vpclattice.md
@@ -750,7 +750,10 @@ export abstract class Target {
    * @param alb
    * @param config
    */
-  public static applicationLoadBalancer(alb: elbv2.ApplicationListener[], config: aws_vpclattice.CfnTargetGroup.TargetGroupConfigProperty): Target {  }
+  public static applicationLoadBalancer(
+    alb: elbv2.ApplicationListener[],
+    config: aws_vpclattice.CfnTargetGroup.TargetGroupConfigProperty,
+  ): Target {  }
 
 ```
 

--- a/text/0648-aspects-priority-ordering.md
+++ b/text/0648-aspects-priority-ordering.md
@@ -18,7 +18,8 @@ Conceptually, there are two types of Aspects:
 * **Read-only aspects** scan the construct tree but do not make changes to the tree. Common use cases of read-only aspects include performing validations
 (for example, enforcing that all S3 Buckets have versioning enabled) and logging (for example, collecting information about all deployed resources for
 audits or compliance).
-* **Mutating aspects** either (1.) add new nodes or (2.) mutate existing nodes of the tree in-place. One commonly used mutating Aspect is adding Tags to
+* **Mutating aspects** either (1.) add new nodes or (2.) mutate existing nodes of the tree in-place. One commonly used mutating Aspect is adding
+Tags to
 resources. An example of an Aspect that adds a node is one that automatically adds a security group to every EC2 instance in the construct tree if
 no default is specified.
 
@@ -362,10 +363,10 @@ The behavior we want to guarantee in this algorithm is:
 Additionally, we will remove a constraint from the existing algorithm which prevent nested Aspects from being invoked. The current algorithm emits a warning
 if an Aspect creates another Aspect and does not invoke that new Aspect.
 
-The feature introduces an optional priority parameter when aspects are apdded. Aspects are then invoked on the construct tree in order of increasing priority
-values. This ensures that mutating aspects are applied first and validation aspects follow, if the application author specifies so. Additionally, the algorithm
-ensures that newly created nodes inherit aspects from their parent constructs, even if those nodes are added later in the process. See Appendix for
-Pseudocode for the new `invokeAspects` function.
+The feature introduces an optional priority parameter when aspects are added. Aspects are then invoked on the construct tree in order of
+increasing priority values. This ensures that mutating aspects are applied first and validation aspects follow, if the application author
+specifies so. Additionally, the algorithm ensures that newly created nodes inherit aspects from their parent constructs, even if those nodes
+are added later in the process. See Appendix for Pseudocode for the new `invokeAspects` function.
 
 Our new `invokeAspects` function will use a stabilization loop to recurse the construct tree and invoke Aspects. The stabilization loop is necessary in
 order to ensure that new nodes created by Aspects (as well as new Aspects created by Aspects) get visited.

--- a/text/0786-bedrock-agentcore-tools-l2.md
+++ b/text/0786-bedrock-agentcore-tools-l2.md
@@ -121,10 +121,10 @@ const browser = new agentcore.BrowserCustom(this, 'BrowserVpcWithRecording', {
 });
 ```
 
-Browser exposes a [connections](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.Connections.html) property. This property returns a connections
-object, which simplifies the process of defining and managing ingress and egress rules for security groups in your AWS CDK applications. Instead of directly
-manipulating security group rules, you interact with the Connections object of a construct, which then translates your connectivity requirements into the
-appropriate security group rules. For instance:
+Browser exposes a [connections](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.Connections.html) property. This property
+returns a connections object, which simplifies the process of defining and managing ingress and egress rules for security groups in your
+AWS CDK applications. Instead of directly manipulating security group rules, you interact with the Connections object of a construct, which
+then translates your connectivity requirements into the appropriate security group rules. For instance:
 
 ```typescript fixture=default
 const vpc = new ec2.Vpc(this, 'testVPC');

--- a/text/0792-aws-aiops-investigationgroup-l2.md
+++ b/text/0792-aws-aiops-investigationgroup-l2.md
@@ -332,7 +332,8 @@ It eliminates the complexity of manually configuring IAM roles, KMS encryption, 
 
 ### Why are we doing this?
 
-The development of AIOps L2 constructs addresses significant customer needs and adoption patterns. Currently, customers rely on L1 constructs through CloudFormation,
+The development of AIOps L2 constructs addresses significant customer needs and adoption patterns. Currently, customers rely on L1 constructs through
+CloudFormation,
 requiring detailed understanding of resource configurations. Additionally, multiple Amazon internal teams have successfully adopted an internal
 L2 package for AIOps resource management, demonstrating the value and demand for higher-level abstractions.
 

--- a/text/0808-library-quality-scoring.md
+++ b/text/0808-library-quality-scoring.md
@@ -409,7 +409,8 @@ The scoring process works as follows:
   * Maintenance: how active the project is (recent releases, frequency of updates, how quickly issues/PRs are handled, active maintainers).
   * Quality: what the project includes (README, tests, lint setup, changelog, license, repo hygiene, CDK-specific setup).
   * Popularity: how widely it’s used (downloads from registries, growth trends, GitHub stars, forks, and contributors).
-* Apply weights: Each signal is scored and weighted by its percentage contribution, then all weighted scores are combined into one final score out of 100.
+* Apply weights: Each signal is scored and weighted by its percentage contribution, then all weighted scores are combined into one final score
+out of 100.
 * Show outputs: The results are available in the CLI (with either a simple summary or a detailed breakdown).
 
 To keep the system modular and easy to maintain, signal weights are defined in a central config file. Each signal includes a


### PR DESCRIPTION
## Summary
- Wrap lines exceeding 150-character limit (MD013) in 7 RFC text files
- Fix typo "apdded" → "added" in RFC 0648
- Unblocks PR #893 and future PRs that fail the `markdownlint` CI check


PR #881 bumped `markdownlint-cli` from 0.46.0 to 0.48.0, which upgraded `markdownlint` from 0.39.0 to 0.40.0. The new version changed how relaxed-mode line-length checking works in MD013: previously, a line exceeding the limit was only flagged if whitespace existed beyond position 150 (via regex `^.{150}.*\s.*$`); now, the last trailing word is collapsed and the line is only excused if the entire overflow is a single unbroken word that starts before the limit. This makes the check stricter for lines where wrappable whitespace exists near or beyond the boundary.

## Test plan
- [x] Ran `lint.sh` locally — 0 errors
- [x] Verified old markdownlint 0.39.0 passes on unmodified files, new 0.40.0 flags all 9 violations