### PR TITLE
fix: resolve potential runtime crashes and handle carriage returns in RFC metadata parsing

### DIFF
--- a/tools/rfc-render/fetch-issues.js
+++ b/tools/rfc-render/fetch-issues.js
@@ -58,7 +58,7 @@ async function issuesGroupedByStatus(filterStatus = undefined) {
       link = `https://github.com/aws/aws-cdk-rfcs/issues/${issue.number}`;
     }
 
-    (issueByStatus[status] ??= []).push({
+    (issueByStatus[status] ??= []).push({ 
       number: issue.number,
       title: issue.title,
       link,
@@ -79,16 +79,26 @@ function findDocFile(files, number) {
 
 function findMetadata(issue) {
   const body = issue.body || '';
-  const lines = body.split('\n');
+  const lines = body.split(/\r?\n/);
   const titleIndex = lines.findIndex(line => line.startsWith('|PR|Champion|'));
-  if (titleIndex === -1) {
+  if (titleIndex === -1 || titleIndex + 2 >= lines.length) {
     return { champion: '' };
   }
 
-  let [, pr, champion] = lines[titleIndex + 2].split('|');
+  const dataLine = lines[titleIndex + 2];
+  if (!dataLine) {
+    return { champion: '' };
+  }
+
+  const parts = dataLine.split('|');
+  if (parts.length < 3) {
+    return { champion: '' };
+  }
+
+  let [, pr, champion] = parts;
   champion = champion ? champion.trim() : '';
 
-  const pr_number = (pr.startsWith('#') ? pr.substring(1) : '').trim();
+  const pr_number = (pr && pr.startsWith('#') ? pr.substring(1) : '').trim();
   return { champion, pr_number };
 }
 


### PR DESCRIPTION
Implements robust line-splitting and boundary checking in the RFC issue metadata parser. Previously, splitting issue bodies strictly on '\n' could leave carriage return characters ('\r') at the end of lines when processing CRLF-terminated text returned by the GitHub API. Furthermore, if the metadata table header '|PR|Champion|' was present but the body did not contain at least two subsequent lines, referencing `lines[titleIndex + 2]` would result in `undefined` and throw a TypeError on `.split('|')`. This fix replaces the single-character split with a `\r?\n` regular expression and adds thorough bounds and structural validation to ensure safe parsing of metadata columns.